### PR TITLE
feat(devops): implement CI pipeline for monorepo validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,24 +7,132 @@ on:
     branches: ["main"]
 
 jobs:
-  build:
-    name: Build and Test
+  web:
+    name: Web
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
+      - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
 
-      - name: Setup Node.js
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-web-${{ hashFiles('package-lock.json', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-web-
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
-      - name: Build Monorepo
-        run: npm run build
+      - name: Lint web
+        run: npm run lint -w web
+
+      - name: Build web
+        run: npm run build -w web -- --webpack
+
+      - name: Typecheck web
+        run: npm run typecheck -w web
+
+  packages:
+    name: Package Validation (${{ matrix.workspace }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        workspace: ["@devconsole/ui", "@devconsole/soroban-utils"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-packages-${{ matrix.workspace }}-${{ hashFiles('package-lock.json', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-packages-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate package
+        run: npx turbo run lint typecheck build --filter=${{ matrix.workspace }}
+
+  api:
+    name: API
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Restore Turbo cache
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-api-${{ hashFiles('package-lock.json', 'turbo.json') }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-api-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run prisma:generate -w api
+
+      - name: Lint API
+        run: npm run lint -w api
+
+      - name: Build API
+        run: npm run build -w api
+
+      - name: Test API
+        run: npm run test -w api
+
+  contracts:
+    name: Contracts (${{ matrix.contract }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        contract: ["auth-tester", "error-trigger", "source-registry", "types-tester"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Restore Cargo cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: contracts/${{ matrix.contract }}
+
+      - name: Test contract
+        run: cargo test --manifest-path contracts/${{ matrix.contract }}/Cargo.toml
+
+      - name: Build contract
+        run: cargo build --release --manifest-path contracts/${{ matrix.contract }}/Cargo.toml

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,6 +8,7 @@
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
     "lint": "tsc --noEmit -p tsconfig.json",
+    "test": "node --import tsx --test src/**/*.test.ts",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:deploy": "prisma migrate deploy"

--- a/apps/api/src/app.test.ts
+++ b/apps/api/src/app.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createApp } from "./app.js";
+
+interface AppRouteLayer {
+  route?: {
+    path?: string;
+    methods?: Record<string, boolean>;
+  };
+}
+
+test("createApp registers the health route", () => {
+  const app = createApp();
+  const layers = app.router.stack as AppRouteLayer[];
+  const healthLayer = layers.find((layer) => layer.route?.path === "/api/health");
+
+  assert.ok(healthLayer, "Expected /api/health route to be registered");
+  assert.equal(healthLayer?.route?.methods?.get, true);
+});

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,62 @@
+import cors from "cors";
+import express from "express";
+import { prisma } from "./lib/prisma.js";
+import { rpcRouter } from "./routes/rpc.js";
+import { verifyRouter } from "./routes/verify.js";
+import { workspacesRouter } from "./routes/workspaces.js";
+
+export function createApp() {
+  const app = express();
+  const webOrigin = process.env.WEB_ORIGIN ?? "http://localhost:3000";
+
+  app.use((req, res, next) => {
+    const origin = req.get("origin");
+    if (origin && origin !== webOrigin) {
+      res.status(403).json({
+        error: "CORS origin not allowed"
+      });
+      return;
+    }
+
+    next();
+  });
+
+  app.use(
+    cors({
+      origin: webOrigin,
+      methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
+      allowedHeaders: ["Content-Type", "Authorization"],
+      credentials: true
+    })
+  );
+  app.use(express.json());
+
+  app.get("/api/health", (_req, res) => {
+    res.status(200).json({
+      ok: true
+    });
+  });
+
+  app.get("/api/workspaces", async (_req, res) => {
+    try {
+      const workspaces = await prisma.workspace.findMany({
+        orderBy: {
+          createdAt: "desc"
+        }
+      });
+
+      res.status(200).json(workspaces);
+    } catch (error) {
+      console.error("Failed to load workspaces", error);
+      res.status(500).json({
+        error: "Failed to load workspaces"
+      });
+    }
+  });
+
+  app.use("/api/workspaces", workspacesRouter);
+  app.use("/api/rpc", rpcRouter);
+  app.use("/api/verify", verifyRouter);
+
+  return app;
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,62 +1,8 @@
-import cors from "cors";
-import express from "express";
 import { prisma } from "./lib/prisma.js";
-import { rpcRouter } from "./routes/rpc.js";
-import { verifyRouter } from "./routes/verify.js";
-import { workspacesRouter } from "./routes/workspaces.js";
+import { createApp } from "./app.js";
 
-const app = express();
+const app = createApp();
 const port = 4000;
-const webOrigin = process.env.WEB_ORIGIN ?? "http://localhost:3000";
-
-app.use((req, res, next) => {
-  const origin = req.get("origin");
-  if (origin && origin !== webOrigin) {
-    res.status(403).json({
-      error: "CORS origin not allowed"
-    });
-    return;
-  }
-
-  next();
-});
-
-app.use(
-  cors({
-    origin: webOrigin,
-    methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
-    allowedHeaders: ["Content-Type", "Authorization"],
-    credentials: true
-  })
-);
-app.use(express.json());
-
-app.get("/api/health", (_req, res) => {
-  res.status(200).json({
-    ok: true
-  });
-});
-
-app.get("/api/workspaces", async (_req, res) => {
-  try {
-    const workspaces = await prisma.workspace.findMany({
-      orderBy: {
-        createdAt: "desc"
-      }
-    });
-
-    res.status(200).json(workspaces);
-  } catch (error) {
-    console.error("Failed to load workspaces", error);
-    res.status(500).json({
-      error: "Failed to load workspaces"
-    });
-  }
-});
-
-app.use("/api/workspaces", workspacesRouter);
-app.use("/api/rpc", rpcRouter);
-app.use("/api/verify", verifyRouter);
 
 const server = app.listen(port, () => {
   console.log(`API server listening on http://localhost:${port}`);


### PR DESCRIPTION
This PR introduces a CI pipeline that validates each part of the monorepo independently while keeping them coordinated.

Web, API, shared packages, and Rust contracts now run their own lint, build, and test steps, so failures are isolated to the relevant workspace. Caching is also configured to improve CI speed.

closes #110 
