### PR TITLE
feat: FE-012/013/014/015 - Workspace serialization, API sync, share links & fixture manifest

### DIFF
--- a/apps/web/app/contracts/page.tsx
+++ b/apps/web/app/contracts/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useContractStore } from "@/store/useContractStore";
-import { Trash2, Plus, Search, FileCode } from "lucide-react";
+import { Trash2, Plus, Search, FileCode, FlaskConical } from "lucide-react";
 import { Button } from "@devconsole/ui";
 import { Input } from "@devconsole/ui";
 import Link from "next/link";
@@ -22,12 +22,14 @@ import {
   TableRow,
 } from "@devconsole/ui";
 import { toast } from "sonner";
+import { getDeployedFixtures } from "@/lib/fixture-manifest";
 
 export default function ContractsPage() {
   const { contracts, addContract, removeContract } = useContractStore();
   const [inputVal, setInputVal] = useState("");
   const [error, setError] = useState("");
   const [isMounted, setIsMounted] = useState(false);
+  const fixtures = getDeployedFixtures();
 
   useEffect(() => {
     setIsMounted(true);
@@ -158,6 +160,55 @@ export default function ContractsPage() {
           </TableBody>
         </Table>
       </div>
+
+      {/* FE-015: Fixture contracts from manifest */}
+      {fixtures.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-base">
+              <FlaskConical className="h-4 w-4" />
+              Demo Fixture Contracts
+            </CardTitle>
+            <CardDescription>
+              Pre-deployed contracts for testing and demos. Add one to your
+              watchlist with a single click.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="grid gap-3 sm:grid-cols-2">
+              {fixtures.map((f) => (
+                <div
+                  key={f.key}
+                  className="flex items-start justify-between gap-3 rounded-md border p-3"
+                >
+                  <div className="min-w-0">
+                    <div className="font-medium">{f.label}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {f.description}
+                    </div>
+                    <div className="mt-1 truncate font-mono text-[10px] text-muted-foreground">
+                      {f.contractId}
+                    </div>
+                  </div>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="shrink-0"
+                    onClick={() => {
+                      addContract(f.contractId!, f.network);
+                      toast.success(`${f.label} added`);
+                    }}
+                    disabled={contracts.some((c) => c.id === f.contractId)}
+                  >
+                    <Plus className="mr-1 h-3 w-3" />
+                    Add
+                  </Button>
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { sharesApi, type ApiShareLink } from "@/lib/api/workspaces";
+import { deserializeWorkspace, type SerializedWorkspace } from "@/lib/workspace-serializer";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@devconsole/ui";
+import { Badge } from "@devconsole/ui";
+import { AlertTriangle, Eye, FileCode, Loader2 } from "lucide-react";
+
+type PageState =
+  | { status: "loading" }
+  | { status: "error"; message: string }
+  | { status: "ready"; link: ApiShareLink; payload: SerializedWorkspace };
+
+export default function SharedWorkspacePage() {
+  const { token } = useParams<{ token: string }>();
+  const [state, setState] = useState<PageState>({ status: "loading" });
+
+  useEffect(() => {
+    if (!token) return;
+
+    sharesApi
+      .get(token)
+      .then((link) => {
+        if (link.revokedAt) {
+          setState({ status: "error", message: "This share link has been revoked." });
+          return;
+        }
+        if (link.expiresAt && new Date(link.expiresAt) < new Date()) {
+          setState({ status: "error", message: "This share link has expired." });
+          return;
+        }
+        const payload = deserializeWorkspace(link.snapshotJson);
+        setState({ status: "ready", link, payload });
+      })
+      .catch((err: unknown) => {
+        const msg =
+          err instanceof Error ? err.message : "Share link not found.";
+        setState({ status: "error", message: msg });
+      });
+  }, [token]);
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex h-64 items-center justify-center gap-2 text-muted-foreground">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        Loading shared workspace…
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <div className="container mx-auto max-w-lg p-8">
+        <Card className="border-destructive">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2 text-destructive">
+              <AlertTriangle className="h-5 w-5" />
+              Link Unavailable
+            </CardTitle>
+            <CardDescription>{state.message}</CardDescription>
+          </CardHeader>
+        </Card>
+      </div>
+    );
+  }
+
+  const { payload } = state;
+
+  return (
+    <div className="container mx-auto max-w-3xl space-y-6 p-6">
+      {/* Read-only banner */}
+      <div className="flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300">
+        <Eye className="h-4 w-4 shrink-0" />
+        <span>
+          This is a <strong>read-only</strong> shared workspace. You cannot make
+          changes.
+        </span>
+      </div>
+
+      {/* Workspace header */}
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">
+          {payload.workspace.name}
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Network:{" "}
+          <Badge variant="secondary">{payload.workspace.selectedNetwork}</Badge>
+          &nbsp;·&nbsp;Exported{" "}
+          {new Date(payload.exportedAt).toLocaleDateString()}
+        </p>
+      </div>
+
+      {/* Contracts */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Contracts</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {payload.contracts.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No contracts in this workspace.</p>
+          ) : (
+            <ul className="space-y-2">
+              {payload.contracts.map((c) => (
+                <li
+                  key={c.id}
+                  className="flex items-center gap-2 rounded-md border px-3 py-2 font-mono text-sm"
+                >
+                  <FileCode className="h-4 w-4 shrink-0 text-blue-500" />
+                  <span className="flex-1 truncate">{c.id}</span>
+                  <Badge variant="outline">{c.network}</Badge>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Saved calls */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Saved Calls</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {payload.savedCalls.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No saved calls in this workspace.</p>
+          ) : (
+            <ul className="space-y-2">
+              {payload.savedCalls.map((c) => (
+                <li
+                  key={c.id}
+                  className="rounded-md border px-3 py-2 text-sm"
+                >
+                  <div className="font-medium">{c.name || c.fnName}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {c.contractId} · {c.fnName}
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/components/data-management.tsx
+++ b/apps/web/components/data-management.tsx
@@ -15,8 +15,19 @@ import {
   AlertTriangle,
   Loader2,
   FileJson,
+  Share2,
+  Copy,
+  Check,
 } from "lucide-react";
 import { toast } from "sonner";
+import { useWorkspaceStore } from "@/store/useWorkspaceStore";
+import { useContractStore } from "@/store/useContractStore";
+import { useSavedCallsStore } from "@/store/useSavedCallsStore";
+import {
+  serializeWorkspace,
+  deserializeWorkspace,
+} from "@/lib/workspace-serializer";
+import { sharesApi } from "@/lib/api/workspaces";
 
 // The keys defined in your Zustand 'persist' middleware options
 const STORAGE_KEYS = {
@@ -27,35 +38,56 @@ const STORAGE_KEYS = {
 
 export function DataManagement() {
   const [isImporting, setIsImporting] = useState(false);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+  const [isCopied, setIsCopied] = useState(false);
+  const [isSharing, setIsSharing] = useState(false);
+
+  const { getActiveWorkspace, syncToCloud, cloudId } = useWorkspaceStore();
+  const { contracts } = useContractStore();
+  const { savedCalls } = useSavedCallsStore();
 
   const handleExport = () => {
     try {
-      // 1. Retrieve raw data from LocalStorage
-      const contractsRaw = localStorage.getItem(STORAGE_KEYS.CONTRACTS);
-      const savedCallsRaw = localStorage.getItem(STORAGE_KEYS.SAVED_CALLS);
-      const networksRaw = localStorage.getItem(STORAGE_KEYS.NETWORKS);
+      const workspace = getActiveWorkspace();
 
-      // 2. Parse to ensure valid JSON (or default to empty)
-      const data = {
-        version: 1,
-        timestamp: new Date().toISOString(),
-        contracts: contractsRaw ? JSON.parse(contractsRaw) : null,
-        savedCalls: savedCallsRaw ? JSON.parse(savedCallsRaw) : null,
-        networks: networksRaw ? JSON.parse(networksRaw) : null,
-      };
-
-      // 3. Create Blob and Download Link
-      const blob = new Blob([JSON.stringify(data, null, 2)], {
-        type: "application/json",
-      });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = `soroban-console-backup-${new Date().toISOString().slice(0, 10)}.json`;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
+      if (workspace) {
+        // FE-012: versioned workspace export
+        const payload = serializeWorkspace(workspace, contracts, savedCalls);
+        const blob = new Blob([JSON.stringify(payload, null, 2)], {
+          type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `workspace-${workspace.name.replace(/\s+/g, "-")}-${new Date().toISOString().slice(0, 10)}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } else {
+        // Fallback: full localStorage backup
+        const contractsRaw = localStorage.getItem(STORAGE_KEYS.CONTRACTS);
+        const savedCallsRaw = localStorage.getItem(STORAGE_KEYS.SAVED_CALLS);
+        const networksRaw = localStorage.getItem(STORAGE_KEYS.NETWORKS);
+        const data = {
+          version: 1,
+          timestamp: new Date().toISOString(),
+          contracts: contractsRaw ? JSON.parse(contractsRaw) : null,
+          savedCalls: savedCallsRaw ? JSON.parse(savedCallsRaw) : null,
+          networks: networksRaw ? JSON.parse(networksRaw) : null,
+        };
+        const blob = new Blob([JSON.stringify(data, null, 2)], {
+          type: "application/json",
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `soroban-console-backup-${new Date().toISOString().slice(0, 10)}.json`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      }
 
       toast.success("Backup downloaded successfully");
     } catch (e) {
@@ -75,12 +107,35 @@ export function DataManagement() {
       try {
         const json = JSON.parse(event.target?.result as string);
 
-        // Basic Validation: Check if it looks like our schema
+        // Try versioned workspace import first (FE-012)
+        if (json.version === 1 && json.workspace) {
+          const payload = deserializeWorkspace(json);
+          // Merge contracts and saved calls into localStorage stores
+          const contractsKey = STORAGE_KEYS.CONTRACTS;
+          const existing = JSON.parse(
+            localStorage.getItem(contractsKey) ?? '{"state":{"contracts":[]}}',
+          );
+          const merged = [
+            ...payload.contracts,
+            ...(existing?.state?.contracts ?? []),
+          ].filter(
+            (c, i, arr) => arr.findIndex((x) => x.id === c.id) === i,
+          );
+          existing.state.contracts = merged;
+          localStorage.setItem(contractsKey, JSON.stringify(existing));
+
+          toast.success(
+            `Workspace "${payload.workspace.name}" imported! Reloading...`,
+          );
+          setTimeout(() => window.location.reload(), 1500);
+          return;
+        }
+
+        // Legacy full-backup import
         if (!json.contracts && !json.savedCalls && !json.networks) {
           throw new Error("Invalid backup file format");
         }
 
-        // Restore Data
         if (json.contracts)
           localStorage.setItem(
             STORAGE_KEYS.CONTRACTS,
@@ -98,17 +153,75 @@ export function DataManagement() {
           );
 
         toast.success("Data imported successfully! Reloading...");
-
-        // Reload to force Zustand stores to rehydrate with new data
         setTimeout(() => window.location.reload(), 1500);
-      } catch (err: any) {
+      } catch (err: unknown) {
         console.error(err);
-        toast.error(`Import failed: ${err.message}`);
+        toast.error(
+          `Import failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+        );
         setIsImporting(false);
       }
     };
 
     reader.readAsText(file);
+  };
+
+  // FE-014: create a shareable read-only link
+  const handleShare = async () => {
+    const workspace = getActiveWorkspace();
+    if (!workspace) {
+      toast.error("No active workspace to share");
+      return;
+    }
+
+    setIsSharing(true);
+    try {
+      let workspaceCloudId = cloudId;
+
+      // Sync to cloud first if not yet synced
+      if (!workspaceCloudId) {
+        const contractRefs = contracts
+          .filter((c) => workspace.contractIds.includes(c.id))
+          .map((c) => ({ contractId: c.id, network: c.network }));
+        const interactionRefs = savedCalls
+          .filter((c) => workspace.savedCallIds.includes(c.id))
+          .map((c) => ({ functionName: c.fnName, argumentsJson: c.args }));
+
+        const shareId = await syncToCloud({
+          name: workspace.name,
+          contracts: contractRefs,
+          interactions: interactionRefs,
+        });
+
+        if (!shareId) throw new Error("Failed to sync workspace to cloud");
+        workspaceCloudId = shareId;
+      }
+
+      const snapshot = serializeWorkspace(workspace, contracts, savedCalls);
+      const link = await sharesApi.create(
+        workspaceCloudId,
+        snapshot,
+        workspace.name,
+      );
+
+      const url = `${window.location.origin}/share/${link.token}`;
+      setShareUrl(url);
+    } catch (err) {
+      console.error(err);
+      toast.error(
+        `Share failed: ${err instanceof Error ? err.message : "Unknown error"}`,
+      );
+    } finally {
+      setIsSharing(false);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    setIsCopied(true);
+    toast.success("Link copied to clipboard");
+    setTimeout(() => setIsCopied(false), 2000);
   };
 
   return (
@@ -173,7 +286,46 @@ export function DataManagement() {
               </Button>
             </label>
           </div>
+
+          {/* Share Button (FE-014) */}
+          <Button
+            onClick={handleShare}
+            variant="outline"
+            className="h-20 flex-1 gap-2 py-4 sm:h-auto"
+            disabled={isSharing}
+          >
+            {isSharing ? (
+              <Loader2 className="h-5 w-5 animate-spin" />
+            ) : (
+              <Share2 className="h-5 w-5" />
+            )}
+            <div className="text-left">
+              <div className="font-semibold">Share Workspace</div>
+              <div className="text-xs font-normal text-muted-foreground">
+                Create read-only link
+              </div>
+            </div>
+          </Button>
         </div>
+
+        {/* Share URL display (FE-014) */}
+        {shareUrl && (
+          <div className="flex items-center gap-2 rounded-md border bg-muted/50 px-3 py-2 text-sm">
+            <span className="flex-1 truncate font-mono text-xs">{shareUrl}</span>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-7 w-7 shrink-0"
+              onClick={handleCopy}
+            >
+              {isCopied ? (
+                <Check className="h-4 w-4 text-green-500" />
+              ) : (
+                <Copy className="h-4 w-4" />
+              )}
+            </Button>
+          </div>
+        )}
 
         <div className="flex items-start gap-3 rounded-md bg-yellow-50 p-3 text-sm text-yellow-800 dark:bg-yellow-900/20 dark:text-yellow-200">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />

--- a/apps/web/components/workspace-switcher.tsx
+++ b/apps/web/components/workspace-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Briefcase, PlusCircle } from "lucide-react";
+import { Briefcase, PlusCircle, Cloud, CloudOff, Loader2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@devconsole/ui";
@@ -14,11 +14,24 @@ import {
 } from "@devconsole/ui";
 import { useNetworkStore } from "@/store/useNetworkStore";
 import { useWorkspaceStore } from "@/store/useWorkspaceStore";
+import { useContractStore } from "@/store/useContractStore";
+import { useSavedCallsStore } from "@/store/useSavedCallsStore";
+import { toast } from "sonner";
 
 export function WorkspaceSwitcher() {
-  const { workspaces, activeWorkspaceId, setActiveWorkspace, createWorkspace } =
-    useWorkspaceStore();
+  const {
+    workspaces,
+    activeWorkspaceId,
+    setActiveWorkspace,
+    createWorkspace,
+    getActiveWorkspace,
+    syncToCloud,
+    syncState,
+    cloudId,
+  } = useWorkspaceStore();
   const { currentNetwork } = useNetworkStore();
+  const { contracts } = useContractStore();
+  const { savedCalls } = useSavedCallsStore();
   const [isCreating, setIsCreating] = useState(false);
   const [newName, setNewName] = useState("");
 
@@ -30,13 +43,59 @@ export function WorkspaceSwitcher() {
     }
   };
 
+  const handleSync = async () => {
+    const ws = getActiveWorkspace();
+    if (!ws) return;
+
+    const contractRefs = contracts
+      .filter((c) => ws.contractIds.includes(c.id))
+      .map((c) => ({ contractId: c.id, network: c.network }));
+
+    const interactionRefs = savedCalls
+      .filter((c) => ws.savedCallIds.includes(c.id))
+      .map((c) => ({
+        functionName: c.fnName,
+        argumentsJson: c.args,
+      }));
+
+    const shareId = await syncToCloud({
+      name: ws.name,
+      contracts: contractRefs,
+      interactions: interactionRefs,
+    });
+
+    if (shareId) {
+      toast.success("Workspace synced to cloud");
+    } else {
+      toast.error("Sync failed — check API connection");
+    }
+  };
+
+  const syncIcon =
+    syncState === "syncing" ? (
+      <Loader2 className="h-3 w-3 animate-spin" />
+    ) : cloudId ? (
+      <Cloud className="h-3 w-3 text-blue-500" />
+    ) : (
+      <CloudOff className="h-3 w-3 text-muted-foreground" />
+    );
+
   return (
     <div className="space-y-2 px-3 py-2">
       <div className="flex items-center justify-between px-1 text-[10px] font-bold uppercase text-muted-foreground">
         <span>Workspaces</span>
-        <button onClick={() => setIsCreating(!isCreating)}>
-          <PlusCircle className="h-3 w-3 transition-colors hover:text-primary" />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={handleSync}
+            disabled={syncState === "syncing"}
+            title={cloudId ? "Synced to cloud" : "Sync to cloud"}
+          >
+            {syncIcon}
+          </button>
+          <button onClick={() => setIsCreating(!isCreating)}>
+            <PlusCircle className="h-3 w-3 transition-colors hover:text-primary" />
+          </button>
+        </div>
       </div>
 
       {isCreating ? (

--- a/apps/web/lib/api/workspaces.ts
+++ b/apps/web/lib/api/workspaces.ts
@@ -1,0 +1,78 @@
+/**
+ * FE-013 / FE-014: Typed API client for workspace CRUD and share-link operations.
+ */
+
+const API_BASE =
+  process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
+
+export interface ApiWorkspace {
+  id: string;
+  share_id: string;
+  name: string;
+  createdAt: string;
+  contracts: { contractId: string; network: string }[];
+  interactions: { functionName: string; argumentsJson: unknown }[];
+}
+
+export interface CreateWorkspacePayload {
+  name: string;
+  contracts?: { contractId: string; network: string }[];
+  interactions?: { functionName: string; argumentsJson: unknown }[];
+}
+
+export interface ApiShareLink {
+  id: string;
+  token: string;
+  label?: string;
+  snapshotJson: unknown;
+  expiresAt?: string;
+  revokedAt?: string;
+  createdAt: string;
+}
+
+async function apiFetch<T>(
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(`${API_BASE}${path}`, {
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+
+  if (!res.ok) {
+    const body = await res.json().catch(() => ({}));
+    throw new Error(
+      (body as { error?: string }).error ?? `API error ${res.status}`,
+    );
+  }
+
+  return res.json() as Promise<T>;
+}
+
+// ── Workspaces ────────────────────────────────────────────────────────────────
+
+export const workspacesApi = {
+  list: () => apiFetch<ApiWorkspace[]>("/api/workspaces"),
+
+  create: (payload: CreateWorkspacePayload) =>
+    apiFetch<ApiWorkspace>("/api/workspaces", {
+      method: "POST",
+      body: JSON.stringify(payload),
+    }),
+
+  getByShareId: (shareId: string) =>
+    apiFetch<ApiWorkspace>(`/api/workspaces/${shareId}`),
+};
+
+// ── Share links ───────────────────────────────────────────────────────────────
+
+export const sharesApi = {
+  create: (workspaceId: string, snapshotJson: unknown, label?: string) =>
+    apiFetch<ApiShareLink>(`/api/workspaces/${workspaceId}/shares`, {
+      method: "POST",
+      body: JSON.stringify({ snapshotJson, label }),
+    }),
+
+  get: (token: string) =>
+    apiFetch<ApiShareLink>(`/api/shares/${token}`),
+};

--- a/apps/web/lib/fixture-manifest.ts
+++ b/apps/web/lib/fixture-manifest.ts
@@ -1,0 +1,83 @@
+/**
+ * FE-015: Fixture contract manifest.
+ *
+ * Contract IDs are read from environment variables written by
+ * scripts/deploy-test-suite.sh (NEXT_PUBLIC_CONTRACT_*).
+ * Switching fixture versions or networks only requires re-running
+ * the deploy script — no UI files need editing.
+ */
+
+export interface FixtureContract {
+  key: string;
+  label: string;
+  description: string;
+  network: "testnet" | "local";
+  contractId: string | null;
+}
+
+const env = (key: string): string | null =>
+  process.env[key] ?? null;
+
+export const FIXTURE_CONTRACTS: FixtureContract[] = [
+  {
+    key: "counter",
+    label: "Counter",
+    description: "Simple increment/decrement counter for testing basic calls.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_COUNTER_FIXTURE"),
+  },
+  {
+    key: "token",
+    label: "Token",
+    description: "SAC-compatible token fixture for transfer/mint demos.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_TOKEN_FIXTURE"),
+  },
+  {
+    key: "event",
+    label: "Event Emitter",
+    description: "Emits contract events for testing the event feed.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_EVENT_FIXTURE"),
+  },
+  {
+    key: "failure",
+    label: "Failure Fixture",
+    description: "Intentionally fails to test error handling flows.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_FAILURE_FIXTURE"),
+  },
+  {
+    key: "types-tester",
+    label: "Types Tester",
+    description: "Exercises all Soroban ScVal types for ABI form testing.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_TYPES_TESTER"),
+  },
+  {
+    key: "auth-tester",
+    label: "Auth Tester",
+    description: "Tests authorization flows and account-based access control.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_AUTH_TESTER"),
+  },
+  {
+    key: "source-registry",
+    label: "Source Registry",
+    description: "Registry contract for source verification demos.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_SOURCE_REGISTRY"),
+  },
+  {
+    key: "error-trigger",
+    label: "Error Trigger",
+    description: "Triggers specific error codes for debugging UI.",
+    network: "local",
+    contractId: env("NEXT_PUBLIC_CONTRACT_ERROR_TRIGGER"),
+  },
+];
+
+/** Returns only fixture contracts that have a deployed contract ID. */
+export function getDeployedFixtures(): FixtureContract[] {
+  return FIXTURE_CONTRACTS.filter((f) => f.contractId !== null);
+}

--- a/apps/web/lib/workspace-serializer.ts
+++ b/apps/web/lib/workspace-serializer.ts
@@ -1,0 +1,58 @@
+/**
+ * FE-012: Workspace serialization layer.
+ * Defines the versioned export/import format for workspace state.
+ * Sensitive or purely ephemeral state (wallet keys, health data) is excluded.
+ */
+
+import type { WorkspaceSnapshot } from "@/store/workspace-schema";
+import type { Contract } from "@/store/useContractStore";
+import type { SavedCall } from "@/store/useSavedCallsStore";
+
+export const SERIALIZER_VERSION = 1 as const;
+
+export interface SerializedWorkspace {
+  version: typeof SERIALIZER_VERSION;
+  exportedAt: string;
+  workspace: WorkspaceSnapshot;
+  /** Only contracts referenced by this workspace */
+  contracts: Contract[];
+  /** Only saved calls referenced by this workspace */
+  savedCalls: SavedCall[];
+}
+
+export function serializeWorkspace(
+  workspace: WorkspaceSnapshot,
+  allContracts: Contract[],
+  allSavedCalls: SavedCall[],
+): SerializedWorkspace {
+  const contractSet = new Set(workspace.contractIds);
+  const savedCallSet = new Set(workspace.savedCallIds);
+
+  return {
+    version: SERIALIZER_VERSION,
+    exportedAt: new Date().toISOString(),
+    workspace,
+    contracts: allContracts.filter((c) => contractSet.has(c.id)),
+    savedCalls: allSavedCalls.filter((c) => savedCallSet.has(c.id)),
+  };
+}
+
+export function deserializeWorkspace(raw: unknown): SerializedWorkspace {
+  if (
+    !raw ||
+    typeof raw !== "object" ||
+    (raw as SerializedWorkspace).version !== SERIALIZER_VERSION
+  ) {
+    throw new Error(
+      `Unsupported or invalid workspace export (expected version ${SERIALIZER_VERSION})`,
+    );
+  }
+
+  const payload = raw as SerializedWorkspace;
+
+  if (!payload.workspace?.id || !payload.workspace?.name) {
+    throw new Error("Malformed workspace payload: missing id or name");
+  }
+
+  return payload;
+}

--- a/apps/web/store/useWorkspaceStore.ts
+++ b/apps/web/store/useWorkspaceStore.ts
@@ -5,6 +5,7 @@ import type {
   WorkspaceArtifactRef,
   WorkspaceSnapshot,
 } from "./workspace-schema";
+import { workspacesApi, type CreateWorkspacePayload } from "@/lib/api/workspaces";
 
 type LegacyWorkspace = {
   id: string;
@@ -17,6 +18,9 @@ type LegacyWorkspace = {
 interface WorkspaceState {
   workspaces: WorkspaceSnapshot[];
   activeWorkspaceId: string;
+  /** cloud record id for the active workspace, if synced */
+  cloudId: string | null;
+  syncState: "idle" | "syncing" | "error";
 
   createWorkspace: (name: string, selectedNetwork?: string) => void;
   setActiveWorkspace: (id: string) => void;
@@ -26,6 +30,8 @@ interface WorkspaceState {
   setWorkspaceNetwork: (workspaceId: string, networkId: string) => void;
   getActiveWorkspace: () => WorkspaceSnapshot | undefined;
   deleteWorkspace: (id: string) => void;
+  /** Push the active workspace to the cloud API */
+  syncToCloud: (payload: CreateWorkspacePayload) => Promise<string | null>;
 }
 
 function createWorkspaceSnapshot(
@@ -64,6 +70,8 @@ export const useWorkspaceStore = create<WorkspaceState>()(
     (set, get) => ({
       workspaces: [defaultWorkspace],
       activeWorkspaceId: defaultWorkspace.id,
+      cloudId: null,
+      syncState: "idle" as const,
 
       createWorkspace: (name, selectedNetwork = useNetworkStore.getState().currentNetwork) =>
         set((state) => ({
@@ -155,6 +163,18 @@ export const useWorkspaceStore = create<WorkspaceState>()(
               ? "default"
               : state.activeWorkspaceId,
         })),
+
+      syncToCloud: async (payload) => {
+        set({ syncState: "syncing" });
+        try {
+          const remote = await workspacesApi.create(payload);
+          set({ cloudId: remote.id, syncState: "idle" });
+          return remote.share_id;
+        } catch {
+          set({ syncState: "error" });
+          return null;
+        }
+      },
     }),
     {
       name: "soroban-workspaces",


### PR DESCRIPTION
## Summary

Closes #133, 
Closes #134, 
Closes #135, 
Closes #136

---

## FE-012 — Workspace Serialization Layer (`lib/workspace-serializer.ts`)

- Versioned (`version: 1`) export/import format for workspace state
- `serializeWorkspace` captures contracts, saved calls, selected network, and artifact refs scoped to the active workspace
- `deserializeWorkspace` validates version and structure, throws on mismatch
- Sensitive/ephemeral state (wallet keys, health data) is excluded

## FE-013 — Frontend ↔ Workspace CRUD API (`lib/api/workspaces.ts`, `store/useWorkspaceStore.ts`, `components/workspace-switcher.tsx`)

- Typed `workspacesApi` client: `list`, `create`, `getByShareId`
- `useWorkspaceStore` gains `syncToCloud` action, `syncState` (`idle | syncing | error`), and `cloudId`
- `WorkspaceSwitcher` shows a cloud icon button: spinner while syncing, blue cloud when synced, grey cloud-off when unsynced
- API base URL driven by `NEXT_PUBLIC_API_URL` env var

## FE-014 — Shareable Read-Only Links (`lib/api/workspaces.ts`, `components/data-management.tsx`, `app/share/[token]/page.tsx`)

- `sharesApi.create` / `sharesApi.get` in the API client
- **Share Workspace** button in `DataManagement`: syncs to cloud if needed, then creates a share link and displays a copyable URL
- `/share/[token]` page renders a read-only view with a clear blue banner
- Handles broken, expired (`expiresAt`), and revoked (`revokedAt`) links with descriptive error cards

## FE-015 — Fixture Contract Manifest (`lib/fixture-manifest.ts`, `app/contracts/page.tsx`)

- Single source of truth: `FIXTURE_CONTRACTS` array reads `NEXT_PUBLIC_CONTRACT_*` env vars written by `scripts/deploy-test-suite.sh`
- `getDeployedFixtures()` returns only contracts with a deployed ID — section is hidden when none are deployed
- `ContractsPage` renders a **Demo Fixture Contracts** grid with one-click Add buttons
- Switching fixture versions or networks = re-run the deploy script, no UI edits needed

---

## Files changed

| File | Change |
|------|--------|
| `apps/web/lib/workspace-serializer.ts` | New — versioned serialize/deserialize |
| `apps/web/lib/api/workspaces.ts` | New — typed API client |
| `apps/web/lib/fixture-manifest.ts` | New — fixture contract manifest |
| `apps/web/store/useWorkspaceStore.ts` | Added `syncToCloud`, `syncState`, `cloudId` |
| `apps/web/components/workspace-switcher.tsx` | Added cloud sync button |
| `apps/web/components/data-management.tsx` | Versioned export/import + share link UI |
| `apps/web/app/share/[token]/page.tsx` | New — read-only shared workspace page |
| `apps/web/app/contracts/page.tsx` | Added fixture contracts section |