### PR TITLE
feat: BE-003, BE-004, BE-005, BE-006 — API hardening, env config, pagination, concurrency

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -26,3 +26,8 @@ SOROBAN_RPC_LOCAL_URL="http://localhost:8000/soroban/rpc"
 
 # ── Build / CI ────────────────────────────────
 SOROBAN_BUILD_IMAGE="stellar/stellar-cli:latest"
+
+# ── Runtime Mode ──────────────────────────────────────────────────────────────
+# Controls which env vars are required vs optional at startup.
+# Values: local (default) | demo | ci
+# RUNTIME_MODE="local"

--- a/apps/api/prisma/migrations/20260424062555_add_workspace_revision/migration.sql
+++ b/apps/api/prisma/migrations/20260424062555_add_workspace_revision/migration.sql
@@ -1,0 +1,3 @@
+-- BE-006: Add revision field for optimistic concurrency control
+-- AlterTable
+ALTER TABLE workspaces ADD COLUMN revision INTEGER NOT NULL DEFAULT 0;

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -14,6 +14,8 @@ model Workspace {
   name              String
   description       String?
   selectedNetwork   String              @default("testnet") @map("selected_network")
+  /// BE-006: Monotonically increasing revision counter for optimistic concurrency control.
+  revision          Int                 @default(0)
   createdAt         DateTime            @default(now()) @map("created_at")
   updatedAt         DateTime            @updatedAt @map("updated_at")
   savedContracts    SavedContract[]

--- a/apps/api/src/lib/validate-env.ts
+++ b/apps/api/src/lib/validate-env.ts
@@ -1,36 +1,105 @@
 /**
- * Validates required environment variables at startup.
- * Throws with a clear diagnostic message if any required var is missing,
- * so misconfigured deployments fail immediately rather than at runtime.
+ * BE-004: Shared runtime configuration model.
+ *
+ * Validates environment variables per boundary (server, rpc, contracts, features).
+ * Supports three bootstrap modes:
+ *   - local  — full dev stack, all RPC endpoints expected
+ *   - demo   — hosted demo, mainnet optional, fixtures optional
+ *   - ci     — test runner, database required, RPC endpoints optional
+ *
+ * Missing required vars fail fast with actionable diagnostics.
+ * Missing optional vars get defaults and emit a warning.
  */
 
-const REQUIRED: string[] = ["DATABASE_URL", "WEB_ORIGIN", "PORT"];
+export type RuntimeMode = "local" | "demo" | "ci";
 
-const OPTIONAL_WITH_DEFAULTS: Record<string, string> = {
+function detectMode(): RuntimeMode {
+  const m = process.env["RUNTIME_MODE"];
+  if (m === "demo" || m === "ci" || m === "local") return m;
+  if (process.env["CI"] === "true" || process.env["CI"] === "1") return "ci";
+  return "local";
+}
+
+// ── Per-boundary variable definitions ────────────────────────────────────────
+
+const SERVER_REQUIRED: string[] = ["DATABASE_URL", "WEB_ORIGIN", "PORT"];
+
+const RPC_DEFAULTS: Record<string, string> = {
   SOROBAN_RPC_TESTNET_URL: "https://soroban-testnet.stellar.org:443",
   SOROBAN_RPC_FUTURENET_URL: "https://rpc-futurenet.stellar.org:443",
   SOROBAN_RPC_LOCAL_URL: "http://localhost:8000/soroban/rpc",
 };
 
-export function validateEnv(): void {
-  const missing = REQUIRED.filter((key) => !process.env[key]);
+/** RPC vars required in local mode (demo/ci treat them as optional). */
+const RPC_REQUIRED_IN_LOCAL: string[] = Object.keys(RPC_DEFAULTS);
 
+const CONTRACT_FIXTURE_VARS: string[] = [
+  "CONTRACT_COUNTER_FIXTURE",
+  "CONTRACT_TOKEN_FIXTURE",
+  "CONTRACT_EVENT_FIXTURE",
+  "CONTRACT_FAILURE_FIXTURE",
+  "CONTRACT_TYPES_TESTER",
+  "CONTRACT_AUTH_TESTER",
+  "CONTRACT_SOURCE_REGISTRY",
+  "CONTRACT_ERROR_TRIGGER",
+];
+
+// ── Validation ────────────────────────────────────────────────────────────────
+
+function assertPresent(vars: string[], boundary: string): void {
+  const missing = vars.filter((k) => !process.env[k]);
   if (missing.length > 0) {
     throw new Error(
-      `[env] Missing required environment variables:\n` +
+      `[env:${boundary}] Missing required environment variables:\n` +
         missing.map((k) => `  - ${k}`).join("\n") +
         `\n\nCopy apps/api/.env.example to apps/api/.env and fill in the values.`,
     );
   }
+}
 
-  for (const [key, fallback] of Object.entries(OPTIONAL_WITH_DEFAULTS)) {
+function applyDefaults(defaults: Record<string, string>): void {
+  for (const [key, fallback] of Object.entries(defaults)) {
     if (!process.env[key]) {
       process.env[key] = fallback;
       console.warn(`[env] ${key} not set — using default: ${fallback}`);
     }
   }
+}
 
-  if (!process.env["SOROBAN_RPC_MAINNET_URL"]) {
-    console.warn("[env] SOROBAN_RPC_MAINNET_URL is not set. Mainnet RPC calls will fail.");
+function warnMissing(vars: string[], boundary: string): void {
+  for (const key of vars) {
+    if (!process.env[key]) {
+      console.warn(`[env:${boundary}] ${key} is not set — related features will be unavailable.`);
+    }
   }
+}
+
+// ── Public entry point ────────────────────────────────────────────────────────
+
+export function validateEnv(): void {
+  const mode = detectMode();
+  console.info(`[env] Runtime mode: ${mode}`);
+
+  // Server boundary — always required
+  assertPresent(SERVER_REQUIRED, "server");
+
+  // RPC boundary
+  if (mode === "local") {
+    // In local mode apply defaults for missing optional RPC vars, then warn about mainnet
+    applyDefaults(RPC_DEFAULTS);
+    if (!process.env["SOROBAN_RPC_MAINNET_URL"]) {
+      console.warn("[env:rpc] SOROBAN_RPC_MAINNET_URL is not set — mainnet RPC calls will fail.");
+    }
+  } else {
+    // demo / ci: apply defaults silently, warn about any still-missing RPC vars
+    applyDefaults(RPC_DEFAULTS);
+    warnMissing([...RPC_REQUIRED_IN_LOCAL, "SOROBAN_RPC_MAINNET_URL"], "rpc");
+  }
+
+  // Contract fixtures — only required in local mode
+  if (mode === "local") {
+    warnMissing(CONTRACT_FIXTURE_VARS, "contracts");
+  }
+
+  // Feature flags — always optional, no warning needed (defaults to enabled)
 }

--- a/apps/api/src/modules/shares/shares.controller.ts
+++ b/apps/api/src/modules/shares/shares.controller.ts
@@ -6,42 +6,57 @@ import {
   HttpCode,
   Param,
   Post,
+  Query,
+  Req,
+  UseGuards,
 } from "@nestjs/common";
-import { SharesService, CreateShareDto } from "./shares.service.js";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { SharesService, CreateShareDto, ListSharesDto } from "./shares.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
 
 @Controller("shares")
 export class SharesController {
   constructor(private readonly sharesService: SharesService) {}
 
-  /** POST /shares — create a new share link */
+  /** POST /shares — create a share link (requires ownership of the workspace) */
   @Post()
-  create(@Body() dto: CreateShareDto) {
-    return this.sharesService.create(dto);
+  @UseGuards(OwnerKeyGuard)
+  create(@Body() dto: CreateShareDto, @Req() req: Request) {
+    return this.sharesService.create((req as OwnerKeyRequest).ownerKey, dto);
   }
 
-  /** GET /shares/:token — resolve a share link (read-only) */
+  /** GET /shares/:token — public read-only resolve, returns snapshot data only */
   @Get(":token")
   resolve(@Param("token") token: string) {
     return this.sharesService.resolve(token);
   }
 
-  /** DELETE /shares/:token — revoke a share link */
+  /** DELETE /shares/:token — revoke (requires ownership of the workspace) */
   @Delete(":token")
   @HttpCode(200)
-  revoke(@Param("token") token: string) {
-    return this.sharesService.revoke(token);
+  @UseGuards(OwnerKeyGuard)
+  revoke(@Param("token") token: string, @Req() req: Request) {
+    return this.sharesService.revoke(token, (req as OwnerKeyRequest).ownerKey);
   }
 
-  /** GET /shares/workspace/:workspaceId — list shares for a workspace */
+  /** GET /shares/workspace/:workspaceId — list shares (requires ownership) */
   @Get("workspace/:workspaceId")
-  listForWorkspace(@Param("workspaceId") workspaceId: string) {
-    return this.sharesService.listForWorkspace(workspaceId);
+  @UseGuards(OwnerKeyGuard)
+  listForWorkspace(
+    @Param("workspaceId") workspaceId: string,
+    @Query() query: ListSharesDto,
+    @Req() req: Request,
+  ) {
+    return this.sharesService.listForWorkspace(
+      workspaceId,
+      (req as OwnerKeyRequest).ownerKey,
+      query,
+    );
   }
 
-  /**
-   * BE-010: DELETE /shares/cleanup — purge expired and revoked share records.
-   * Protected by the owner-key guard in production; open here for simplicity.
-   */
+  /** DELETE /shares/cleanup — purge expired and revoked share records */
   @Delete("cleanup")
   @HttpCode(200)
   cleanup() {

--- a/apps/api/src/modules/shares/shares.repository.ts
+++ b/apps/api/src/modules/shares/shares.repository.ts
@@ -10,8 +10,14 @@ export class SharesRepository {
     where?: Prisma.ShareLinkWhereInput;
     orderBy?: Prisma.ShareLinkOrderByWithRelationInput;
     select?: Prisma.ShareLinkSelect;
+    skip?: number;
+    take?: number;
   }) {
     return this.prisma.shareLink.findMany(params);
+  }
+
+  async count(params: { where?: Prisma.ShareLinkWhereInput }) {
+    return this.prisma.shareLink.count(params);
   }
 
   async findUnique(params: {

--- a/apps/api/src/modules/shares/shares.service.ts
+++ b/apps/api/src/modules/shares/shares.service.ts
@@ -1,5 +1,10 @@
 import { Prisma } from "@prisma/client";
-import { Injectable, NotFoundException, ForbiddenException, GoneException } from "@nestjs/common";
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  GoneException,
+} from "@nestjs/common";
 import { SharesRepository } from "./shares.repository.js";
 import { WorkspacesRepository } from "../workspaces/workspaces.repository.js";
 import { MapDbErrors } from "../../lib/db-error.mapper.js";
@@ -11,7 +16,8 @@ import {
 } from "../../lib/domain-events.js";
 import { randomBytes } from "crypto";
 
-import { IsString, IsOptional, IsObject } from "class-validator";
+import { IsString, IsOptional, IsObject, IsInt, Min, IsIn } from "class-validator";
+import { Type } from "class-transformer";
 
 export class CreateShareDto {
   @IsString()
@@ -29,6 +35,48 @@ export class CreateShareDto {
   expiresAt?: string;
 }
 
+/** BE-005: Pagination and filtering for share list */
+export class ListSharesDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  skip?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  take?: number;
+
+  @IsOptional()
+  @IsIn(["createdAt", "expiresAt"])
+  sortBy?: "createdAt" | "expiresAt";
+
+  @IsOptional()
+  @IsIn(["asc", "desc"])
+  sortOrder?: "asc" | "desc";
+}
+
+/** BE-005: Pagination response envelope */
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: {
+    total: number;
+    skip: number;
+    take: number;
+  };
+}
+
+/** Fields exposed by the public resolve endpoint — no internal IDs or ownerKey. */
+interface PublicShareView {
+  token: string;
+  label: string | null;
+  snapshotJson: Prisma.JsonValue;
+  expiresAt: Date | null;
+  createdAt: Date;
+}
+
 @Injectable()
 export class SharesService {
   constructor(
@@ -37,12 +85,16 @@ export class SharesService {
     private readonly events: DomainEventBus,
   ) {}
 
+  /** BE-003: create requires the caller to own the target workspace. */
   @MapDbErrors()
-  async create(dto: CreateShareDto) {
+  async create(ownerKey: string, dto: CreateShareDto) {
     const workspace = await this.workspacesRepository.findUnique({
       where: { id: dto.workspaceId },
     });
     if (!workspace) throw new NotFoundException("Workspace not found");
+    if (workspace.ownerKey !== ownerKey) {
+      throw new ForbiddenException("You do not own this workspace");
+    }
 
     const token = randomBytes(24).toString("base64url");
 
@@ -63,12 +115,15 @@ export class SharesService {
     return share;
   }
 
+  /**
+   * BE-003: Public resolve — returns only snapshot data.
+   * Internal fields (id, workspaceId) are not exposed.
+   */
   @MapDbErrors()
-  async resolve(token: string) {
+  async resolve(token: string): Promise<PublicShareView> {
     const share = await this.repository.findUnique({ where: { token } });
     if (!share) throw new NotFoundException("Share link not found");
 
-    // BE-010: Distinguish revoked vs expired with separate error messages.
     if (share.revokedAt) {
       throw new ForbiddenException("Share link has been revoked");
     }
@@ -80,15 +135,31 @@ export class SharesService {
       shareId: share.id,
       workspaceId: share.workspaceId,
     });
-    return share;
+
+    // BE-003: Return only the fields a public consumer needs.
+    return {
+      token: share.token,
+      label: share.label,
+      snapshotJson: share.snapshotJson,
+      expiresAt: share.expiresAt,
+      createdAt: share.createdAt,
+    };
   }
 
+  /** BE-003: revoke requires the caller to own the workspace the share belongs to. */
   @MapDbErrors()
-  async revoke(token: string) {
+  async revoke(token: string, ownerKey: string) {
     const share = await this.repository.findUnique({ where: { token } });
     if (!share) throw new NotFoundException("Share link not found");
 
-    // BE-010: Idempotent — already revoked is fine.
+    const workspace = await this.workspacesRepository.findUnique({
+      where: { id: share.workspaceId },
+    });
+    if (!workspace || workspace.ownerKey !== ownerKey) {
+      throw new ForbiddenException("You do not own this workspace");
+    }
+
+    // Idempotent — already revoked is fine.
     if (share.revokedAt) return share;
 
     const updated = await this.repository.update({
@@ -103,26 +174,48 @@ export class SharesService {
   }
 
   @MapDbErrors()
-  async listForWorkspace(workspaceId: string) {
-    return this.repository.findMany({
-      where: { workspaceId },
-      orderBy: { createdAt: "desc" },
-      select: {
-        id: true,
-        token: true,
-        label: true,
-        expiresAt: true,
-        revokedAt: true,
-        createdAt: true,
-      },
+  async listForWorkspace(
+    workspaceId: string,
+    ownerKey: string,
+    query: ListSharesDto = {},
+  ): Promise<PaginatedResponse<any>> {
+    const workspace = await this.workspacesRepository.findUnique({
+      where: { id: workspaceId },
     });
+    if (!workspace) throw new NotFoundException("Workspace not found");
+    if (workspace.ownerKey !== ownerKey) {
+      throw new ForbiddenException("You do not own this workspace");
+    }
+
+    const skip = query.skip ?? 0;
+    const take = query.take ?? 20;
+    const sortBy = query.sortBy ?? "createdAt";
+    const sortOrder = query.sortOrder ?? "desc";
+
+    const where = { workspaceId };
+    const select = {
+      id: true,
+      token: true,
+      label: true,
+      expiresAt: true,
+      revokedAt: true,
+      createdAt: true,
+    };
+
+    const [data, total] = await Promise.all([
+      this.repository.findMany({
+        where,
+        orderBy: { [sortBy]: sortOrder },
+        select,
+        skip,
+        take,
+      }),
+      this.repository.count({ where }),
+    ]);
+
+    return { data, pagination: { total, skip, take } };
   }
 
-  /**
-   * BE-010: Cleanup stale share records.
-   * Deletes all expired and revoked share links.
-   * Intended to be called by a scheduled job or admin endpoint.
-   */
   @MapDbErrors()
   async cleanup(): Promise<{ deleted: number }> {
     const deleted = await this.repository.deleteExpiredAndRevoked();

--- a/apps/api/src/modules/workspaces/dto/workspace.dto.ts
+++ b/apps/api/src/modules/workspaces/dto/workspace.dto.ts
@@ -8,6 +8,7 @@ import {
   IsInt,
   Min,
 } from "class-validator";
+import { Type } from "class-transformer";
 
 const NETWORKS = ["testnet", "mainnet", "futurenet", "local"] as const;
 
@@ -40,6 +41,16 @@ export class UpdateWorkspaceDto {
   @IsOptional()
   @IsIn(NETWORKS)
   selectedNetwork?: string;
+
+  /**
+   * BE-006: Optimistic concurrency control.
+   * If provided, the update is rejected with 409 if the stored revision differs.
+   */
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  revision?: number;
 }
 
 export class ImportWorkspaceDto {
@@ -70,3 +81,41 @@ export class ImportWorkspaceDto {
   @IsString()
   selectedNetwork!: string;
 }
+
+/** BE-005: Pagination and filtering for workspace list */
+export class ListWorkspacesDto {
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  skip?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  take?: number;
+
+  @IsOptional()
+  @IsIn(["updatedAt", "createdAt", "name"])
+  sortBy?: "updatedAt" | "createdAt" | "name";
+
+  @IsOptional()
+  @IsIn(["asc", "desc"])
+  sortOrder?: "asc" | "desc";
+
+  @IsOptional()
+  @IsString()
+  network?: string;
+}
+
+/** BE-005: Pagination response envelope */
+export interface PaginatedResponse<T> {
+  data: T[];
+  pagination: {
+    total: number;
+    skip: number;
+    take: number;
+  };
+}
+

--- a/apps/api/src/modules/workspaces/workspaces.controller.ts
+++ b/apps/api/src/modules/workspaces/workspaces.controller.ts
@@ -8,6 +8,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   Req,
   UseGuards,
 } from "@nestjs/common";
@@ -16,6 +17,7 @@ import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
 import {
   CreateWorkspaceDto,
   ImportWorkspaceDto,
+  ListWorkspacesDto,
   UpdateWorkspaceDto,
 } from "./workspace.dto.js";
 import { WorkspacesService } from "./workspaces.service.js";
@@ -28,8 +30,8 @@ export class WorkspacesController {
   constructor(private readonly workspacesService: WorkspacesService) {}
 
   @Get()
-  list(@Req() req: Request) {
-    return this.workspacesService.list((req as OwnerKeyRequest).ownerKey);
+  list(@Req() req: Request, @Query() query: ListWorkspacesDto) {
+    return this.workspacesService.list((req as OwnerKeyRequest).ownerKey, query);
   }
 
   @Get(":id")

--- a/apps/api/src/modules/workspaces/workspaces.repository.ts
+++ b/apps/api/src/modules/workspaces/workspaces.repository.ts
@@ -10,8 +10,14 @@ export class WorkspacesRepository {
     where?: Prisma.WorkspaceWhereInput;
     orderBy?: Prisma.WorkspaceOrderByWithRelationInput;
     select?: Prisma.WorkspaceSelect;
+    skip?: number;
+    take?: number;
   }) {
     return this.prisma.workspace.findMany(params);
+  }
+
+  async count(params: { where?: Prisma.WorkspaceWhereInput }) {
+    return this.prisma.workspace.count(params);
   }
 
   async findFirst(params: {

--- a/apps/api/src/modules/workspaces/workspaces.service.ts
+++ b/apps/api/src/modules/workspaces/workspaces.service.ts
@@ -18,6 +18,8 @@ import {
 import type {
   CreateWorkspaceDto,
   ImportWorkspaceDto,
+  ListWorkspacesDto,
+  PaginatedResponse,
   UpdateWorkspaceDto,
 } from "./workspace.dto.js";
 
@@ -29,19 +31,38 @@ export class WorkspacesService {
   ) {}
 
   @MapDbErrors()
-  list(ownerKey: string) {
-    return this.repository.findMany({
-      where: { ownerKey },
-      orderBy: { updatedAt: "desc" },
-      select: {
-        id: true,
-        name: true,
-        description: true,
-        selectedNetwork: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    });
+  async list(ownerKey: string, query: ListWorkspacesDto = {}): Promise<PaginatedResponse<any>> {
+    const skip = query.skip ?? 0;
+    const take = query.take ?? 20;
+    const sortBy = query.sortBy ?? "updatedAt";
+    const sortOrder = query.sortOrder ?? "desc";
+
+    const where = {
+      ownerKey,
+      ...(query.network ? { selectedNetwork: query.network } : {}),
+    };
+
+    const select = {
+      id: true,
+      name: true,
+      description: true,
+      selectedNetwork: true,
+      createdAt: true,
+      updatedAt: true,
+    };
+
+    const [data, total] = await Promise.all([
+      this.repository.findMany({
+        where,
+        orderBy: { [sortBy]: sortOrder },
+        select,
+        skip,
+        take,
+      }),
+      this.repository.count({ where }),
+    ]);
+
+    return { data, pagination: { total, skip, take } };
   }
 
   @MapDbErrors()
@@ -111,7 +132,14 @@ export class WorkspacesService {
 
   @MapDbErrors()
   async update(id: string, ownerKey: string, dto: UpdateWorkspaceDto) {
-    await this.get(id, ownerKey);
+    const current = await this.get(id, ownerKey);
+
+    // BE-006: Reject stale updates when the caller supplies a revision.
+    if (dto.revision !== undefined && dto.revision !== (current as any).revision) {
+      throw new ConflictException(
+        `Workspace has been modified (expected revision ${dto.revision}, got ${(current as any).revision}). Reload and retry.`,
+      );
+    }
 
     const workspace = await this.repository.update({
       where: { id },
@@ -123,6 +151,7 @@ export class WorkspacesService {
         ...(dto.selectedNetwork !== undefined
           ? { selectedNetwork: dto.selectedNetwork }
           : {}),
+        revision: { increment: 1 },
       },
     });
     this.events.emit(WORKSPACE_UPDATED, {

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -45,6 +45,8 @@ export interface WorkspaceSummary {
   name: string;
   description: string | null;
   selectedNetwork: string;
+  /** BE-006: Current revision for optimistic concurrency control. */
+  revision: number;
   createdAt: Date | string;
   updatedAt: Date | string;
 }
@@ -70,6 +72,8 @@ export interface UpdateWorkspacePayload {
   selectedNetwork?: string;
   contracts?: WorkspaceContract[];
   interactions?: WorkspaceInteraction[];
+  /** BE-006: Pass the current revision to enable optimistic concurrency control. */
+  revision?: number;
 }
 
 // ── Shares ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements four backend issues in a single pass.

BE-003: ownership checks on share create/revoke/list; public resolve returns snapshot-only view
BE-004: per-boundary env validation with local/demo/ci mode support via RUNTIME_MODE
BE-005: pagination (skip/take), filtering (network), and stable sort for workspace and share list endpoints
BE-006: optimistic concurrency control via revision field on workspace mutations; stale updates return 409

Closes #209
Closes #210
Closes #211
Closes #212