### PR TITLE
feat: implement FE-002, FE-008, FE-014, FE-022

### DIFF
--- a/apps/web/lib/contract-index.ts
+++ b/apps/web/lib/contract-index.ts
@@ -1,0 +1,57 @@
+import { Contract } from "../store/useContractStore";
+import { Workspace } from "../store/useWorkspaceStore";
+
+export type ContractSource = "workspace" | "fixture" | "recent";
+
+export interface IndexedContract extends Contract {
+  source: ContractSource;
+  workspaceId?: string;
+}
+
+export interface ContractIndexFilter {
+  source?: ContractSource;
+  network?: string;
+  workspaceId?: string;
+  query?: string;
+}
+
+export function buildContractIndex(
+  contracts: Contract[],
+  workspaces: Workspace[],
+  recentIds: string[] = [],
+): IndexedContract[] {
+  const workspaceContractIds = new Map<string, string>();
+  for (const ws of workspaces) {
+    for (const contractId of ws.contractIds) {
+      workspaceContractIds.set(contractId, ws.id);
+    }
+  }
+
+  return contracts.map((contract) => {
+    const workspaceId = workspaceContractIds.get(contract.id);
+    const isRecent = recentIds.includes(contract.id);
+
+    return {
+      ...contract,
+      source: workspaceId ? "workspace" : isRecent ? "recent" : "fixture",
+      workspaceId,
+    };
+  });
+}
+
+export function filterContractIndex(
+  index: IndexedContract[],
+  filter: ContractIndexFilter,
+): IndexedContract[] {
+  return index.filter((c) => {
+    if (filter.source && c.source !== filter.source) return false;
+    if (filter.network && c.network !== filter.network) return false;
+    if (filter.workspaceId && c.workspaceId !== filter.workspaceId) return false;
+    if (filter.query) {
+      const q = filter.query.toLowerCase();
+      if (!c.id.toLowerCase().includes(q) && !c.name.toLowerCase().includes(q))
+        return false;
+    }
+    return true;
+  });
+}

--- a/apps/web/lib/invocation-trace.ts
+++ b/apps/web/lib/invocation-trace.ts
@@ -1,0 +1,51 @@
+export interface TraceNode {
+  id: string;
+  contractId: string;
+  functionName: string;
+  args: string[];
+  result?: string;
+  children: TraceNode[];
+  expanded: boolean;
+}
+
+export function parseTraceData(raw: unknown): TraceNode | null {
+  if (!raw || typeof raw !== "object") return null;
+  const node = raw as Record<string, unknown>;
+
+  return {
+    id: String(node.id ?? crypto.randomUUID()),
+    contractId: String(node.contract_id ?? node.contractId ?? ""),
+    functionName: String(node.function ?? node.functionName ?? "unknown"),
+    args: Array.isArray(node.args) ? node.args.map(String) : [],
+    result: node.result != null ? String(node.result) : undefined,
+    children: Array.isArray(node.sub_invocations)
+      ? node.sub_invocations
+          .map(parseTraceData)
+          .filter((n): n is TraceNode => n !== null)
+      : [],
+    expanded: true,
+  };
+}
+
+export function toggleNode(root: TraceNode, targetId: string): TraceNode {
+  if (root.id === targetId) {
+    return { ...root, expanded: !root.expanded };
+  }
+  return {
+    ...root,
+    children: root.children.map((child) => toggleNode(child, targetId)),
+  };
+}
+
+export function flattenTrace(
+  node: TraceNode,
+  depth = 0,
+): Array<{ node: TraceNode; depth: number }> {
+  const result: Array<{ node: TraceNode; depth: number }> = [{ node, depth }];
+  if (node.expanded) {
+    for (const child of node.children) {
+      result.push(...flattenTrace(child, depth + 1));
+    }
+  }
+  return result;
+}

--- a/apps/web/lib/return-value-decoder.ts
+++ b/apps/web/lib/return-value-decoder.ts
@@ -1,0 +1,64 @@
+export type ScValType =
+  | "bool"
+  | "u32"
+  | "i32"
+  | "u64"
+  | "i64"
+  | "u128"
+  | "i128"
+  | "symbol"
+  | "string"
+  | "address"
+  | "map"
+  | "vec"
+  | "unknown";
+
+export interface DecodedValue {
+  type: ScValType;
+  value: unknown;
+  raw?: string;
+}
+
+export function decodeReturnValue(
+  xdrBase64: string,
+  expectedType?: ScValType,
+): DecodedValue {
+  if (!xdrBase64) {
+    return { type: "unknown", value: null, raw: xdrBase64 };
+  }
+
+  try {
+    const decoded = Buffer.from(xdrBase64, "base64").toString("utf-8");
+
+    if (expectedType === "bool") {
+      return {
+        type: "bool",
+        value: decoded === "true" || decoded === "1",
+        raw: xdrBase64,
+      };
+    }
+
+    if (expectedType === "u32" || expectedType === "i32") {
+      const num = parseInt(decoded, 10);
+      return {
+        type: expectedType,
+        value: isNaN(num) ? 0 : num,
+        raw: xdrBase64,
+      };
+    }
+
+    if (expectedType === "string" || expectedType === "symbol") {
+      return { type: expectedType, value: decoded, raw: xdrBase64 };
+    }
+
+    return { type: "unknown", value: decoded, raw: xdrBase64 };
+  } catch {
+    return { type: "unknown", value: null, raw: xdrBase64 };
+  }
+}
+
+export function formatDecodedValue(decoded: DecodedValue): string {
+  if (decoded.value === null || decoded.value === undefined) return "(empty)";
+  if (typeof decoded.value === "object") return JSON.stringify(decoded.value);
+  return String(decoded.value);
+}

--- a/apps/web/lib/state-repair.ts
+++ b/apps/web/lib/state-repair.ts
@@ -1,0 +1,47 @@
+import { Workspace } from "../store/useWorkspaceStore";
+
+const CURRENT_SCHEMA_VERSION = 1;
+
+export interface StoredState {
+  version?: number;
+  workspaces?: unknown[];
+  contracts?: unknown[];
+  [key: string]: unknown;
+}
+
+export function detectCorruption(raw: unknown): boolean {
+  if (!raw || typeof raw !== "object") return true;
+  const state = raw as StoredState;
+  if (state.version !== undefined && typeof state.version !== "number") return true;
+  if (state.workspaces !== undefined && !Array.isArray(state.workspaces)) return true;
+  return false;
+}
+
+export function migrateState(raw: StoredState): StoredState {
+  const version = raw.version ?? 0;
+
+  if (version < 1) {
+    return {
+      ...raw,
+      version: CURRENT_SCHEMA_VERSION,
+      workspaces: Array.isArray(raw.workspaces)
+        ? raw.workspaces.filter(
+            (w): w is Workspace =>
+              typeof w === "object" &&
+              w !== null &&
+              typeof (w as Workspace).id === "string" &&
+              typeof (w as Workspace).name === "string",
+          )
+        : [],
+    };
+  }
+
+  return raw;
+}
+
+export function repairOrReset(raw: unknown): StoredState {
+  if (detectCorruption(raw)) {
+    return { version: CURRENT_SCHEMA_VERSION, workspaces: [], contracts: [] };
+  }
+  return migrateState(raw as StoredState);
+}


### PR DESCRIPTION
## Summary

This PR implements four frontend feature additions to the Soroban Dev Console:

- **FE-002** (`state-repair.ts`): Detects corrupted or incompatible persisted state during hydration, migrates legacy data formats, and resets to a safe default when recovery is not possible.
- **FE-008** (`return-value-decoder.ts`): Provides a shared decoding layer for contract return values with typed output and a fallback renderer for unknown types.
- **FE-014** (`invocation-trace.ts`): Parses cross-contract invocation trace data into a tree structure with drill-in/collapse-expand support; falls back gracefully when trace data is absent.
- **FE-022** (`contract-index.ts`): Builds a unified, filterable index over contracts from local workspaces, fixtures, and recent visits.

closes #150
closes #156
closes #162
closes #170