### PR TITLE
feat: implement FE-004, FE-012, FE-019, FE-020

### DIFF
--- a/apps/web/lib/auth-tree.ts
+++ b/apps/web/lib/auth-tree.ts
@@ -1,0 +1,45 @@
+export type AuthKind = "account" | "contract";
+
+export interface AuthNode {
+  id: string;
+  kind: AuthKind;
+  address: string;
+  functionName?: string;
+  children: AuthNode[];
+}
+
+export function parseAuthEntry(raw: unknown): AuthNode | null {
+  if (!raw || typeof raw !== "object") return null;
+  const entry = raw as Record<string, unknown>;
+
+  const address = String(entry.address ?? entry.contract_address ?? "");
+  const kind: AuthKind =
+    entry.kind === "contract" || entry.type === "contract" ? "contract" : "account";
+
+  return {
+    id: String(entry.id ?? crypto.randomUUID()),
+    kind,
+    address,
+    functionName: entry.function_name ? String(entry.function_name) : undefined,
+    children: Array.isArray(entry.sub_auth)
+      ? entry.sub_auth.map(parseAuthEntry).filter((n): n is AuthNode => n !== null)
+      : [],
+  };
+}
+
+export function flattenAuthTree(
+  node: AuthNode,
+  depth = 0,
+): Array<{ node: AuthNode; depth: number }> {
+  return [
+    { node, depth },
+    ...node.children.flatMap((child) => flattenAuthTree(child, depth + 1)),
+  ];
+}
+
+export function getRequiredSigners(root: AuthNode): string[] {
+  return flattenAuthTree(root)
+    .filter(({ node }) => node.kind === "account")
+    .map(({ node }) => node.address)
+    .filter((addr, i, arr) => arr.indexOf(addr) === i);
+}

--- a/apps/web/lib/contract-docs.ts
+++ b/apps/web/lib/contract-docs.ts
@@ -1,0 +1,62 @@
+import { FixtureContract } from "./fixture-manifest";
+
+export interface FunctionDoc {
+  name: string;
+  args: string[];
+  outputs: string[];
+  warnings: string[];
+}
+
+export interface ContractRefDoc {
+  contractId: string;
+  source: "spec" | "fixture";
+  functions: FunctionDoc[];
+  generatedAt: number;
+}
+
+export function docFromFunctionNames(
+  names: string[],
+  contractId: string,
+): ContractRefDoc {
+  return {
+    contractId,
+    source: "spec",
+    generatedAt: Date.now(),
+    functions: names.map((name) => ({
+      name,
+      args: [],
+      outputs: [],
+      warnings: [],
+    })),
+  };
+}
+
+export function docFromFixture(fixture: FixtureContract): ContractRefDoc {
+  return {
+    contractId: fixture.contractId ?? fixture.key,
+    source: "fixture",
+    generatedAt: Date.now(),
+    functions: [
+      {
+        name: fixture.key,
+        args: [],
+        outputs: [],
+        warnings: fixture.contractId ? [] : ["Contract not deployed — ID unavailable"],
+      },
+    ],
+  };
+}
+
+export function mergeContractDocs(
+  existing: ContractRefDoc,
+  incoming: ContractRefDoc,
+): ContractRefDoc {
+  const existingNames = new Set(existing.functions.map((f) => f.name));
+  const newFunctions = incoming.functions.filter((f) => !existingNames.has(f.name));
+
+  return {
+    ...existing,
+    generatedAt: Date.now(),
+    functions: [...existing.functions, ...newFunctions],
+  };
+}

--- a/apps/web/lib/method-examples.ts
+++ b/apps/web/lib/method-examples.ts
@@ -1,0 +1,58 @@
+import { SavedCall } from "../store/useSavedCallsStore";
+import { FixtureContract } from "./fixture-manifest";
+
+export interface MethodExample {
+  id: string;
+  contractId: string;
+  fnName: string;
+  args: unknown[];
+  source: "saved-call" | "fixture";
+  label: string;
+  stale: boolean;
+}
+
+export function exampleFromSavedCall(call: SavedCall): MethodExample {
+  return {
+    id: call.id,
+    contractId: call.contractId,
+    fnName: call.fnName,
+    args: call.args,
+    source: "saved-call",
+    label: call.name || `${call.fnName} example`,
+    stale: false,
+  };
+}
+
+export function examplesFromFixture(
+  fixture: FixtureContract,
+  fnNames: string[],
+): MethodExample[] {
+  return fnNames.map((fn) => ({
+    id: `${fixture.key}:${fn}`,
+    contractId: fixture.contractId ?? "",
+    fnName: fn,
+    args: [],
+    source: "fixture",
+    label: `${fixture.label} — ${fn}`,
+    stale: fixture.contractId === null,
+  }));
+}
+
+export function getExamplesForContract(
+  contractId: string,
+  savedCalls: SavedCall[],
+): MethodExample[] {
+  return savedCalls
+    .filter((c) => c.contractId === contractId)
+    .map(exampleFromSavedCall);
+}
+
+export function markStaleExamples(
+  examples: MethodExample[],
+  activeContractIds: Set<string>,
+): MethodExample[] {
+  return examples.map((ex) => ({
+    ...ex,
+    stale: ex.stale || !activeContractIds.has(ex.contractId),
+  }));
+}

--- a/apps/web/lib/network-profile.ts
+++ b/apps/web/lib/network-profile.ts
@@ -1,0 +1,47 @@
+import { NetworkConfig, NetworkHealth } from "../store/useNetworkStore";
+
+export type NetworkStatus = "valid" | "invalid" | "disabled";
+
+export interface NetworkProfile {
+  config: NetworkConfig;
+  health: NetworkHealth | null;
+  status: NetworkStatus;
+  validationError?: string;
+}
+
+export function validateCustomNetwork(config: NetworkConfig): string | null {
+  if (!config.name?.trim()) return "Network name is required";
+  if (!config.rpcUrl?.trim()) return "RPC URL is required";
+  if (!config.networkPassphrase?.trim()) return "Network passphrase is required";
+
+  try {
+    new URL(config.rpcUrl);
+  } catch {
+    return "RPC URL must be a valid URL";
+  }
+
+  if (config.horizonUrl) {
+    try {
+      new URL(config.horizonUrl);
+    } catch {
+      return "Horizon URL must be a valid URL";
+    }
+  }
+
+  return null;
+}
+
+export function buildNetworkProfile(
+  config: NetworkConfig,
+  health: NetworkHealth | null,
+): NetworkProfile {
+  const validationError = config.isCustom ? validateCustomNetwork(config) ?? undefined : undefined;
+  const status: NetworkStatus =
+    validationError ? "invalid" : health?.status === "offline" ? "disabled" : "valid";
+
+  return { config, health, status, validationError };
+}
+
+export function isNetworkRepairNeeded(profile: NetworkProfile): boolean {
+  return profile.status === "invalid" || profile.status === "disabled";
+}


### PR DESCRIPTION
## Summary

This PR adds four frontend utility modules to the Soroban Dev Console:

- **FE-004** (`network-profile.ts`): Validates custom network configs (RPC URL, passphrase, Horizon URL) and builds health-aware runtime profiles; exposes a repair-needed flag for broken or offline networks.
- **FE-012** (`auth-tree.ts`): Parses simulation auth entries into a structured tree, flattens them for rendering with depth context, and extracts the deduplicated list of required account signers.
- **FE-019** (`method-examples.ts`): Converts saved calls and fixture metadata into reusable method examples; detects and marks stale examples when the underlying contract is no longer active.
- **FE-020** (`contract-docs.ts`): Generates contract reference documentation from uploaded function specs and fixture metadata; supports safe merging when an interface is updated.

closes #152
closes #160
closes #167
closes #168