### PR TITLE
feat(devops-001): implement correlation ID tracing across the stack

### DIFF
--- a/apps/api/src/lib/correlation.interceptor.ts
+++ b/apps/api/src/lib/correlation.interceptor.ts
@@ -1,0 +1,56 @@
+/**
+ * DEVOPS-001: Correlation ID interceptor for NestJS.
+ *
+ * Extracts or generates correlation IDs for every incoming request,
+ * sets them in the async context, and adds them to response headers.
+ * This enables end-to-end request tracing across the entire stack.
+ */
+
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+} from "@nestjs/common";
+import { Request, Response } from "express";
+import { Observable } from "rxjs";
+import { tap } from "rxjs/operators";
+import { generateCorrelationId, runWithCorrelation } from "./request-context.js";
+
+@Injectable()
+export class CorrelationInterceptor implements NestInterceptor {
+  intercept(context: ExecutionContext, next: CallHandler): Observable<any> {
+    const req = context.switchToHttp().getRequest<Request>();
+    const res = context.switchToHttp().getResponse<Response>();
+
+    // Extract correlation ID from header or generate new one
+    const correlationId =
+      (req.headers["x-request-id"] as string) || generateCorrelationId();
+
+    // Set in response headers so client can reference it
+    res.setHeader("x-request-id", correlationId);
+
+    // Log request with correlation ID
+    console.log(
+      `[${correlationId}] ${req.method} ${req.url}`,
+    );
+
+    // Run the handler within the correlation context
+    return runWithCorrelation(correlationId, () => {
+      return next.handle().pipe(
+        tap({
+          next: (data) => {
+            console.log(
+              `[${correlationId}] Response sent`,
+            );
+          },
+          error: (error) => {
+            console.error(
+              `[${correlationId}] Error: ${error?.message || 'Unknown error'}`,
+            );
+          },
+        }),
+      );
+    });
+  }
+}

--- a/apps/api/src/lib/request-context.ts
+++ b/apps/api/src/lib/request-context.ts
@@ -1,0 +1,48 @@
+/**
+ * DEVOPS-001: Request context for correlation ID propagation.
+ *
+ * Uses AsyncLocalStorage to maintain correlation IDs throughout the request
+ * lifecycle, enabling end-to-end tracing from frontend through API to RPC calls.
+ *
+ * Usage:
+ *   - CorrelationInterceptor sets the ID on incoming requests
+ *   - Services can retrieve it via getCorrelationId()
+ *   - All logs and upstream calls should include it
+ */
+
+import { AsyncLocalStorage } from "async_hooks";
+import { randomUUID } from "crypto";
+
+interface RequestContext {
+  correlationId: string;
+}
+
+const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
+
+/**
+ * Get the current correlation ID from request context.
+ * Returns undefined if called outside of a request context.
+ */
+export function getCorrelationId(): string | undefined {
+  const context = asyncLocalStorage.getStore();
+  return context?.correlationId;
+}
+
+/**
+ * Run a function with a specific correlation ID in context.
+ * Used internally by the interceptor.
+ */
+export function runWithCorrelation<T>(
+  correlationId: string,
+  fn: () => T,
+): T {
+  return asyncLocalStorage.run({ correlationId }, fn);
+}
+
+/**
+ * Generate a new correlation ID (UUID v4).
+ * Exported for use in frontend clients.
+ */
+export function generateCorrelationId(): string {
+  return randomUUID();
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -6,6 +6,7 @@ import { AppModule } from "./app.module.js";
 import { validateEnv } from "./lib/validate-env.js";
 import { ApiErrorFilter } from "./lib/api-error.filter.js";
 import { ApiResponseInterceptor } from "./lib/api-response.interceptor.js";
+import { CorrelationInterceptor } from "./lib/correlation.interceptor.js";
 
 async function bootstrap() {
   validateEnv();
@@ -23,7 +24,8 @@ async function bootstrap() {
   });
   app.setGlobalPrefix("api");
   app.useGlobalFilters(new ApiErrorFilter());
-  app.useGlobalInterceptors(new ApiResponseInterceptor());
+  // DEVOPS-001: Register correlation interceptor first to ensure all requests are traced
+  app.useGlobalInterceptors(new CorrelationInterceptor(), new ApiResponseInterceptor());
   app.useGlobalPipes(
     new ValidationPipe({
       whitelist: true,

--- a/apps/api/src/modules/rpc/rpc.service.ts
+++ b/apps/api/src/modules/rpc/rpc.service.ts
@@ -21,6 +21,7 @@ import {
   getMethodPolicy,
   buildMethodNotAllowedError,
 } from "./rpc-method-policy.js";
+import { getCorrelationId } from "../../lib/request-context.js";
 
 const networkSchema = z.enum(["mainnet", "testnet", "futurenet", "local"]);
 
@@ -196,11 +197,16 @@ export class RpcService {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), policy.timeoutMs);
     const start = Date.now();
+    const correlationId = getCorrelationId();
 
     try {
       const upstreamResponse = await fetch(rpcUrl, {
         method: "POST",
-        headers: { "content-type": "application/json" },
+        headers: {
+          "content-type": "application/json",
+          // DEVOPS-001: Propagate correlation ID to upstream RPC
+          ...(correlationId ? { "x-request-id": correlationId } : {}),
+        },
         body: serializedPayload,
         signal: controller.signal,
       });
@@ -225,12 +231,18 @@ export class RpcService {
         statusCode: result.statusCode,
         durationMs: Date.now() - start,
         cached: false,
+        correlationId,
       });
 
       return result;
     } catch (error) {
       if (error instanceof Error && error.name === "AbortError") {
-        this.events.emit(RPC_UPSTREAM_ERROR, { network, method, errorName: "AbortError" });
+        this.events.emit(RPC_UPSTREAM_ERROR, {
+          network,
+          method,
+          errorName: "AbortError",
+          correlationId,
+        });
         throw new GatewayTimeoutException(
           `RPC upstream timed out after ${policy.timeoutMs}ms`
         );
@@ -240,6 +252,7 @@ export class RpcService {
         network,
         method,
         errorName: error instanceof Error ? error.name : "UnknownError",
+        correlationId,
       });
       throw new BadGatewayException("Failed to proxy RPC request");
     } finally {

--- a/apps/web/lib/api/rpc-gateway.ts
+++ b/apps/web/lib/api/rpc-gateway.ts
@@ -4,9 +4,16 @@
  * Routes simulation, ledger reads, and transaction polling through the
  * backend /api/rpc/:network endpoint instead of calling Soroban RPC directly.
  * Network and upstream errors are normalized consistently.
+ *
+ * DEVOPS-001: Includes correlation ID tracking for end-to-end request tracing.
  */
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:4000";
+
+// DEVOPS-001: Generate correlation IDs for request tracing
+function generateCorrelationId(): string {
+  return crypto.randomUUID?.() || `req-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
 
 export class RpcGatewayError extends Error {
   constructor(
@@ -46,6 +53,7 @@ export async function rpcCall<T = unknown>(
   params?: unknown,
 ): Promise<T> {
   const id = nextId();
+  const correlationId = generateCorrelationId();
   const body: JsonRpcRequest & { jsonrpc: "2.0"; id: number } = {
     jsonrpc: "2.0",
     id,
@@ -57,15 +65,26 @@ export async function rpcCall<T = unknown>(
   try {
     res = await fetch(`${API_BASE}/api/rpc/${network}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // DEVOPS-001: Include correlation ID for tracing
+        "x-request-id": correlationId,
+      },
       body: JSON.stringify(body),
     });
   } catch (err) {
-    throw new RpcGatewayError("Network error reaching RPC gateway", "NETWORK_ERROR", err);
+    throw new RpcGatewayError(
+      `Network error reaching RPC gateway [${correlationId}]`,
+      "NETWORK_ERROR",
+      err,
+    );
   }
 
   if (!res.ok) {
-    throw new RpcGatewayError(`RPC gateway returned HTTP ${res.status}`, "HTTP_ERROR");
+    throw new RpcGatewayError(
+      `RPC gateway returned HTTP ${res.status} [${correlationId}]`,
+      "HTTP_ERROR",
+    );
   }
 
   const json = (await res.json()) as JsonRpcResponse<T>;
@@ -88,6 +107,7 @@ export async function rpcBatch<T = unknown>(
   network: string,
   requests: JsonRpcRequest[],
 ): Promise<JsonRpcResponse<T>[]> {
+  const correlationId = generateCorrelationId();
   const batch = requests.map((r) => ({
     jsonrpc: "2.0" as const,
     id: nextId(),
@@ -99,15 +119,26 @@ export async function rpcBatch<T = unknown>(
   try {
     res = await fetch(`${API_BASE}/api/rpc/${network}`, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        // DEVOPS-001: Include correlation ID for tracing
+        "x-request-id": correlationId,
+      },
       body: JSON.stringify(batch),
     });
   } catch (err) {
-    throw new RpcGatewayError("Network error reaching RPC gateway", "NETWORK_ERROR", err);
+    throw new RpcGatewayError(
+      `Network error reaching RPC gateway [${correlationId}]`,
+      "NETWORK_ERROR",
+      err,
+    );
   }
 
   if (!res.ok) {
-    throw new RpcGatewayError(`RPC gateway returned HTTP ${res.status}`, "HTTP_ERROR");
+    throw new RpcGatewayError(
+      `RPC gateway returned HTTP ${res.status} [${correlationId}]`,
+      "HTTP_ERROR",
+    );
   }
 
   return res.json() as Promise<JsonRpcResponse<T>[]>;

--- a/apps/web/lib/api/workspaces.ts
+++ b/apps/web/lib/api/workspaces.ts
@@ -1,6 +1,8 @@
 /**
  * FE-013 / FE-014: Typed API client for workspace CRUD and share-link operations.
  * Aligned with backend NestJS routes and shared contracts.
+ *
+ * DEVOPS-001: Includes correlation ID tracking for end-to-end request tracing.
  */
 
 import {
@@ -19,15 +21,25 @@ import {
 const API_BASE =
   process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:3001";
 
+// DEVOPS-001: Generate correlation IDs for request tracing
+function generateCorrelationId(): string {
+  return crypto.randomUUID?.() || `req-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+}
+
 async function apiFetch<T>(
   path: string,
   init?: RequestInit,
 ): Promise<T> {
+  // DEVOPS-001: Generate correlation ID for this request
+  const correlationId = generateCorrelationId();
+  
   const res = await fetch(`${API_BASE}${path}`, {
     headers: { 
       "Content-Type": "application/json",
       // If we had auth tokens, we'd add them here
       "x-owner-key": localStorage.getItem("owner-key") || "default-dev-key",
+      // DEVOPS-001: Include correlation ID for tracing
+      "x-request-id": correlationId,
     },
     ...init,
   });
@@ -35,9 +47,13 @@ async function apiFetch<T>(
   if (!res.ok) {
     const body = await res.json().catch(() => ({})) as ApiEnvelope<any>;
     if (body && "error" in body) {
-      throw new ApiError(body.error.message, body.error.code, body.error.details);
+      throw new ApiError(
+        `${body.error.message} [${correlationId}]`,
+        body.error.code,
+        body.error.details,
+      );
     }
-    throw new Error(`API error ${res.status}: ${res.statusText}`);
+    throw new Error(`API error ${res.status}: ${res.statusText} [${correlationId}]`);
   }
 
   // We assume for now that the backend might or might not wrap success responses


### PR DESCRIPTION
- Create AsyncLocalStorage-based request context for correlation IDs
- Add CorrelationInterceptor to extract/generate x-request-id headers
- Propagate correlation IDs through RPC service to upstream calls
- Update frontend API clients (rpc-gateway, workspaces) to include correlation IDs
- Include correlation IDs in error messages for diagnostics
- Register interceptor in main.ts before other interceptors

Enables end-to-end request tracing from browser through API to RPC behavior.

closes #233 