### PR TITLE
feat: implement FE-049, FE-050, FE-051, FE-052

### DIFF
--- a/apps/web/app/account/page.tsx
+++ b/apps/web/app/account/page.tsx
@@ -1,6 +1,6 @@
-      const horizonUrl = network.horizonUrl ?? "https://horizon-testnet.stellar.org";"use client";
+"use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { Horizon } from "@stellar/stellar-sdk";
 import {
   Wallet,
@@ -9,6 +9,10 @@ import {
   Coins,
   Hash,
   Users,
+  Activity,
+  ArrowUpRight,
+  Zap,
+  WifiOff,
 } from "lucide-react";
 
 import { Button } from "@devconsole/ui";
@@ -44,47 +48,110 @@ interface AccountData {
   balances: AssetBalance[];
   numSubentries: number;
   signers: Array<{ key: string; weight: number; type: string }>;
-  thresholds: {
-    low_threshold: number;
-    med_threshold: number;
-    high_threshold: number;
-  };
+  thresholds: { low_threshold: number; med_threshold: number; high_threshold: number };
 }
+
+interface RecentOp {
+  id: string;
+  type: string;
+  createdAt: string;
+  /** human-readable summary */
+  summary: string;
+  txHash: string;
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+function opSummary(op: any, address: string): string {
+  switch (op.type) {
+    case "payment":
+      return op.from === address
+        ? `Sent ${op.amount} ${op.asset_code ?? "XLM"}`
+        : `Received ${op.amount} ${op.asset_code ?? "XLM"}`;
+    case "create_account":
+      return `Created account ${op.account?.slice(0, 8)}…`;
+    case "invoke_host_function":
+      return "Invoked contract function";
+    case "upload_contract_wasm":
+      return "Uploaded WASM";
+    case "create_contract":
+      return "Deployed contract";
+    case "change_trust":
+      return `Changed trust for ${op.asset_code ?? "asset"}`;
+    default:
+      return op.type.replace(/_/g, " ");
+  }
+}
+
+function opIcon(type: string) {
+  if (type === "payment") return <ArrowUpRight className="h-4 w-4 text-blue-500" />;
+  if (type === "create_account") return <Zap className="h-4 w-4 text-yellow-500" />;
+  if (["invoke_host_function", "upload_contract_wasm", "create_contract"].includes(type))
+    return <Zap className="h-4 w-4 text-purple-500" />;
+  return <Activity className="h-4 w-4 text-muted-foreground" />;
+}
+
+// ── Disconnected state ────────────────────────────────────────────────────────
+
+function DisconnectedState() {
+  return (
+    <div className="container mx-auto p-6">
+      <div className="flex min-h-[400px] flex-col items-center justify-center gap-6">
+        <WifiOff className="h-16 w-16 text-muted-foreground/40" />
+        <div className="text-center">
+          <h2 className="text-xl font-semibold">No Wallet Connected</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Connect your wallet to view balances, recent activity, and developer tools.
+          </p>
+        </div>
+        <Alert className="max-w-md">
+          <Wallet className="h-4 w-4" />
+          <AlertTitle>Getting Started</AlertTitle>
+          <AlertDescription>
+            Use the wallet button in the top-right corner to connect Freighter or another
+            Stellar wallet.
+          </AlertDescription>
+        </Alert>
+      </div>
+    </div>
+  );
+}
+
+// ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function AccountDashboard() {
   const { isConnected, address } = useWallet();
   const { getActiveNetworkConfig, currentNetwork } = useNetworkStore();
 
   const [accountData, setAccountData] = useState<AccountData | null>(null);
+  const [recentOps, setRecentOps] = useState<RecentOp[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
 
-  const fetchAccountData = async () => {
-    if (!address) {
-      setError("No wallet connected");
-      return;
-    }
-
+  const fetchAccountData = useCallback(async () => {
+    if (!address) return;
     setLoading(true);
     setError("");
 
     try {
       const network = getActiveNetworkConfig();
-
       const horizonUrl = network.horizonUrl ?? "https://horizon-testnet.stellar.org";
       const server = new Horizon.Server(horizonUrl);
 
-      const account = await server.loadAccount(address);
+      const [account, opsPage] = await Promise.all([
+        server.loadAccount(address),
+        server.operations().forAccount(address).order("desc").limit(10).call(),
+      ]);
 
       setAccountData({
         accountId: account.id,
         sequence: account.sequence,
         balances: account.balances as AssetBalance[],
         numSubentries: account.subentry_count,
-        signers: account.signers.map((signer: any) => ({
-          key: signer.key,
-          weight: signer.weight,
-          type: signer.type || "ed25519_public_key",
+        signers: account.signers.map((s: any) => ({
+          key: s.key,
+          weight: s.weight,
+          type: s.type || "ed25519_public_key",
         })),
         thresholds: {
           low_threshold: account.thresholds.low_threshold,
@@ -92,105 +159,86 @@ export default function AccountDashboard() {
           high_threshold: account.thresholds.high_threshold,
         },
       });
+
+      setRecentOps(
+        (opsPage.records as any[]).map((op) => ({
+          id: op.id,
+          type: op.type,
+          createdAt: op.created_at,
+          summary: opSummary(op, address),
+          txHash: op.transaction_hash,
+        })),
+      );
     } catch (err: any) {
       const is404 =
         err.message?.includes("404") ||
         err.message?.includes("not found") ||
         err.response?.status === 404;
-
-      if (is404) {
-        setError(
-          "Account not found on the network. This is common on Testnet if the account hasn't been funded yet.",
-        );
-      } else {
-        console.error("Failed to fetch account:", err);
-        setError(err.message || "Failed to load account data");
-      }
+      setError(
+        is404
+          ? "Account not found on the network. Fund it to get started."
+          : err.message || "Failed to load account data",
+      );
       setAccountData(null);
+      setRecentOps([]);
     } finally {
       setLoading(false);
     }
-  };
+  }, [address, getActiveNetworkConfig]);
 
   useEffect(() => {
-    if (isConnected && address) {
-      fetchAccountData();
-    }
-  }, [address, currentNetwork]);
+    if (isConnected && address) fetchAccountData();
+  }, [address, currentNetwork, fetchAccountData]);
 
-  // Get XLM (native) balance
-  const xlmBalance = accountData?.balances.find(
-    (b) => b.asset_type === "native",
-  );
+  if (!isConnected || !address) return <DisconnectedState />;
 
-  // Get trustline balances (non-native assets)
-  const trustlines =
-    accountData?.balances.filter((b) => b.asset_type !== "native") || [];
+  const xlmBalance = accountData?.balances.find((b) => b.asset_type === "native");
+  const trustlines = accountData?.balances.filter((b) => b.asset_type !== "native") ?? [];
 
-  if (!isConnected || !address) {
-    return (
-      <div className="container mx-auto p-6">
-        <div className="flex min-h-[400px] items-center justify-center">
-          <Alert className="max-w-md">
-            <Wallet className="h-4 w-4" />
-            <AlertTitle>Wallet Not Connected</AlertTitle>
-            <AlertDescription>
-              Please connect your wallet using the button in the top right
-              corner to view your account dashboard.
-            </AlertDescription>
-          </Alert>
-        </div>
-      </div>
-    );
-  }
+  // FE-052: network-aware capabilities
+  const isTestnetLike = currentNetwork === "testnet" || currentNetwork === "futurenet";
+  const explorerBase =
+    currentNetwork === "mainnet"
+      ? "https://stellar.expert/explorer/public/tx"
+      : "https://stellar.expert/explorer/testnet/tx";
 
   return (
     <div className="container mx-auto space-y-6 p-6">
       {/* Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <h1 className="flex items-center gap-2 text-3xl font-bold tracking-tight">
             <Wallet className="h-8 w-8" />
             Account Dashboard
           </h1>
-          <p className="mt-1 font-mono text-sm text-muted-foreground">
-            {address}
-          </p>
+          <p className="mt-1 font-mono text-sm text-muted-foreground">{address}</p>
           <Badge variant="outline" className="mt-2">
             {currentNetwork.toUpperCase()}
           </Badge>
         </div>
 
-        <div className="flex items-center gap-2">
-          <FundAccountButton />
-          <Button
-            onClick={fetchAccountData}
-            disabled={loading}
-            variant="outline"
-            size="sm"
-          >
-            <RefreshCw
-              className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`}
-            />
+        <div className="flex flex-wrap items-center gap-2">
+          {/* FE-052: only show fund button on test networks */}
+          {isTestnetLike && <FundAccountButton />}
+          <Button onClick={fetchAccountData} disabled={loading} variant="outline" size="sm">
+            <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
             Refresh
           </Button>
         </div>
       </div>
 
-      {/* Error Alert */}
+      {/* Error */}
       {error && (
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertTitle>Error Loading Account</AlertTitle>
           <AlertDescription className="space-y-2">
             <p>{error}</p>
-            {error.includes("not found") && (
+            {error.includes("not found") && isTestnetLike && (
               <div className="mt-3 rounded-md border border-destructive/20 bg-destructive/10 p-3">
                 <p className="text-sm font-medium text-foreground">
-                  💡 Click the{" "}
-                  <strong className="text-blue-500">"Get Testnet XLM"</strong>{" "}
-                  button in the top right to instantly fund and create this
-                  account!
+                  💡 Click <strong className="text-blue-500">"Get Testnet XLM"</strong> to fund
+                  and create this account instantly.
                 </p>
               </div>
             )}
@@ -198,7 +246,7 @@ export default function AccountDashboard() {
         </Alert>
       )}
 
-      {/* XLM Balance - Prominent Display */}
+      {/* XLM Balance */}
       <Card className="border-2 border-primary/20">
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
@@ -210,7 +258,7 @@ export default function AccountDashboard() {
           {loading ? (
             <Skeleton className="h-16 w-48" />
           ) : xlmBalance ? (
-            <div className="space-y-2">
+            <div className="space-y-1">
               <p className="text-4xl font-bold">
                 {parseFloat(xlmBalance.balance).toLocaleString(undefined, {
                   minimumFractionDigits: 2,
@@ -218,18 +266,11 @@ export default function AccountDashboard() {
                 })}{" "}
                 <span className="text-2xl text-muted-foreground">XLM</span>
               </p>
-              {xlmBalance.buying_liabilities &&
-                parseFloat(xlmBalance.buying_liabilities) > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    Buying Liabilities: {xlmBalance.buying_liabilities} XLM
-                  </p>
-                )}
-              {xlmBalance.selling_liabilities &&
-                parseFloat(xlmBalance.selling_liabilities) > 0 && (
-                  <p className="text-sm text-muted-foreground">
-                    Selling Liabilities: {xlmBalance.selling_liabilities} XLM
-                  </p>
-                )}
+              {parseFloat(xlmBalance.selling_liabilities ?? "0") > 0 && (
+                <p className="text-sm text-muted-foreground">
+                  Selling liabilities: {xlmBalance.selling_liabilities} XLM
+                </p>
+              )}
             </div>
           ) : (
             <p className="text-muted-foreground">No balance data available</p>
@@ -237,9 +278,8 @@ export default function AccountDashboard() {
         </CardContent>
       </Card>
 
-      {/* Account Info Grid */}
+      {/* Info grid */}
       <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-        {/* Sequence Number */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
@@ -258,30 +298,27 @@ export default function AccountDashboard() {
           </CardContent>
         </Card>
 
-        {/* Signer Count */}
         <Card>
           <CardHeader>
             <CardTitle className="flex items-center gap-2 text-lg">
               <Users className="h-5 w-5 text-purple-500" />
-              Signer Count
+              Signers
             </CardTitle>
           </CardHeader>
           <CardContent>
             {loading ? (
               <Skeleton className="h-8 w-full" />
             ) : accountData ? (
-              <div className="space-y-2">
+              <div className="space-y-1">
                 <p className="font-mono text-xl">
                   {accountData.signers.length} Signer
                   {accountData.signers.length !== 1 ? "s" : ""}
                 </p>
-                <div className="space-y-1 text-xs text-muted-foreground">
-                  <p>Low Threshold: {accountData.thresholds.low_threshold}</p>
-                  <p>
-                    Medium Threshold: {accountData.thresholds.med_threshold}
-                  </p>
-                  <p>High Threshold: {accountData.thresholds.high_threshold}</p>
-                </div>
+                <p className="text-xs text-muted-foreground">
+                  Thresholds — Low: {accountData.thresholds.low_threshold} / Med:{" "}
+                  {accountData.thresholds.med_threshold} / High:{" "}
+                  {accountData.thresholds.high_threshold}
+                </p>
               </div>
             ) : (
               <p className="text-muted-foreground">N/A</p>
@@ -290,62 +327,112 @@ export default function AccountDashboard() {
         </Card>
       </div>
 
-      {/* Trustlines Table */}
+      {/* FE-052: Recent Activity */}
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <Coins className="h-5 w-5 text-green-500" />
-            Assets & Trustlines
-            {trustlines.length > 0 && (
-              <Badge variant="secondary">{trustlines.length}</Badge>
+            <Activity className="h-5 w-5 text-orange-500" />
+            Recent Activity
+            {recentOps.length > 0 && (
+              <Badge variant="secondary">{recentOps.length}</Badge>
             )}
           </CardTitle>
         </CardHeader>
         <CardContent>
           {loading ? (
             <div className="space-y-2">
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
-              <Skeleton className="h-10 w-full" />
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} className="h-10 w-full" />
+              ))}
             </div>
-          ) : trustlines.length > 0 ? (
+          ) : recentOps.length > 0 ? (
             <div className="rounded-md border">
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead>Asset Code</TableHead>
-                    <TableHead>Balance</TableHead>
-                    <TableHead>Limit</TableHead>
-                    <TableHead className="hidden md:table-cell">
-                      Issuer
-                    </TableHead>
+                    <TableHead>Type</TableHead>
+                    <TableHead>Summary</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead>Tx</TableHead>
                   </TableRow>
                 </TableHeader>
                 <TableBody>
-                  {trustlines.map((trustline, index) => (
-                    <TableRow key={index}>
-                      <TableCell className="font-medium">
-                        {trustline.asset_code || "Unknown"}
+                  {recentOps.map((op) => (
+                    <TableRow key={op.id}>
+                      <TableCell>
+                        <div className="flex items-center gap-1.5">
+                          {opIcon(op.type)}
+                          <span className="text-xs">{op.type.replace(/_/g, " ")}</span>
+                        </div>
+                      </TableCell>
+                      <TableCell className="text-sm">{op.summary}</TableCell>
+                      <TableCell className="text-xs text-muted-foreground">
+                        {new Date(op.createdAt).toLocaleDateString()}
+                      </TableCell>
+                      <TableCell>
+                        <a
+                          href={`${explorerBase}/${op.txHash}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center gap-1 font-mono text-xs text-blue-500 hover:underline"
+                        >
+                          {op.txHash.slice(0, 8)}…
+                          <ArrowUpRight className="h-3 w-3" />
+                        </a>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          ) : (
+            <div className="py-8 text-center">
+              <p className="text-muted-foreground">
+                {accountData ? "No recent activity found." : "Connect and refresh to load activity."}
+              </p>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Trustlines */}
+      {trustlines.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Coins className="h-5 w-5 text-green-500" />
+              Assets & Trustlines
+              <Badge variant="secondary">{trustlines.length}</Badge>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="rounded-md border">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Asset</TableHead>
+                    <TableHead>Balance</TableHead>
+                    <TableHead>Limit</TableHead>
+                    <TableHead className="hidden md:table-cell">Issuer</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {trustlines.map((t, i) => (
+                    <TableRow key={i}>
+                      <TableCell className="font-medium">{t.asset_code ?? "Unknown"}</TableCell>
+                      <TableCell className="font-mono">
+                        {parseFloat(t.balance).toLocaleString(undefined, {
+                          minimumFractionDigits: 2,
+                          maximumFractionDigits: 7,
+                        })}
                       </TableCell>
                       <TableCell className="font-mono">
-                        {parseFloat(trustline.balance).toLocaleString(
-                          undefined,
-                          {
-                            minimumFractionDigits: 2,
-                            maximumFractionDigits: 7,
-                          },
-                        )}
-                      </TableCell>
-                      <TableCell className="font-mono">
-                        {trustline.limit
-                          ? parseFloat(trustline.limit).toLocaleString()
-                          : "N/A"}
+                        {t.limit ? parseFloat(t.limit).toLocaleString() : "N/A"}
                       </TableCell>
                       <TableCell className="hidden font-mono text-xs md:table-cell">
-                        {trustline.asset_issuer ? (
-                          <span title={trustline.asset_issuer}>
-                            {trustline.asset_issuer.slice(0, 8)}...
-                            {trustline.asset_issuer.slice(-8)}
+                        {t.asset_issuer ? (
+                          <span title={t.asset_issuer}>
+                            {t.asset_issuer.slice(0, 8)}…{t.asset_issuer.slice(-8)}
                           </span>
                         ) : (
                           "N/A"
@@ -356,17 +443,11 @@ export default function AccountDashboard() {
                 </TableBody>
               </Table>
             </div>
-          ) : (
-            <div className="py-8 text-center">
-              <p className="text-muted-foreground">
-                No trustlines found. This account only holds native XLM.
-              </p>
-            </div>
-          )}
-        </CardContent>
-      </Card>
+          </CardContent>
+        </Card>
+      )}
 
-      {/* Additional Account Details */}
+      {/* Additional details */}
       {accountData && (
         <Card>
           <CardHeader>
@@ -375,16 +456,49 @@ export default function AccountDashboard() {
           <CardContent className="space-y-3">
             <div className="flex justify-between rounded-lg bg-muted/50 p-3">
               <span className="text-sm font-medium">Subentries</span>
-              <span className="font-mono text-sm">
-                {accountData.numSubentries}
-              </span>
+              <span className="font-mono text-sm">{accountData.numSubentries}</span>
             </div>
             <div className="flex justify-between rounded-lg bg-muted/50 p-3">
               <span className="text-sm font-medium">Total Assets</span>
-              <span className="font-mono text-sm">
-                {accountData.balances.length}
-              </span>
+              <span className="font-mono text-sm">{accountData.balances.length}</span>
             </div>
+            {/* FE-052: network-aware developer tools */}
+            {isTestnetLike && (
+              <div className="flex justify-between rounded-lg bg-blue-500/10 p-3">
+                <span className="text-sm font-medium text-blue-700">Developer Tools</span>
+                <div className="flex gap-2">
+                  <a
+                    href={`https://stellar.expert/explorer/testnet/account/${address}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-blue-500 hover:underline"
+                  >
+                    Explorer <ArrowUpRight className="h-3 w-3" />
+                  </a>
+                  <a
+                    href={`https://laboratory.stellar.org/#account-creator?network=test`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-blue-500 hover:underline"
+                  >
+                    Laboratory <ArrowUpRight className="h-3 w-3" />
+                  </a>
+                </div>
+              </div>
+            )}
+            {currentNetwork === "mainnet" && (
+              <div className="flex justify-between rounded-lg bg-amber-500/10 p-3">
+                <span className="text-sm font-medium text-amber-700">Mainnet</span>
+                <a
+                  href={`https://stellar.expert/explorer/public/account/${address}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-center gap-1 text-xs text-amber-600 hover:underline"
+                >
+                  View on Explorer <ArrowUpRight className="h-3 w-3" />
+                </a>
+              </div>
+            )}
           </CardContent>
         </Card>
       )}

--- a/apps/web/app/deploy/wasm/page.tsx
+++ b/apps/web/app/deploy/wasm/page.tsx
@@ -50,8 +50,10 @@ import { Badge } from "@devconsole/ui";
 import {
   createNormalizedContractSpecFromFunctionNames,
   parseWasmMetadata,
+  extractContractIdFromDeployResult,
 } from "@devconsole/soroban-utils";
 import { registerSource } from "@/lib/source-registry";
+import { InstantiateWizard } from "@/components/instantiate-wizard";
 
 // ── Provenance panel ──────────────────────────────────────────────────────────
 
@@ -275,16 +277,29 @@ export default function WasmRegistryPage() {
         await new Promise((r) => setTimeout(r, 2000));
         const status = await server.getTransaction(res.hash);
         if (status.status === "SUCCESS") {
-          // SC-003/SC-004: record as inferred until source-registry confirms
-          associateContract(wasmHash, res.hash, "inferred");
+          // FE-049: decode the real contract ID from the transaction result XDR
+          const realContractId =
+            status.resultMetaXdr
+              ? extractContractIdFromDeployResult(status.resultMetaXdr)
+              : null;
+          const contractId = realContractId ?? res.hash;
+          const relationship = realContractId ? "confirmed" : "inferred";
+
+          associateContract(wasmHash, contractId, relationship);
           attachArtifact(activeWorkspaceId, {
             kind: "wasm",
             id: wasmHash,
-            contractId: res.hash,
-            relationship: "inferred",
+            contractId,
+            relationship,
           });
-          toast.success("Contract Instantiated Successfully!");
+          addContract(contractId, network.id);
+          toast.success(`Contract deployed! ID: ${contractId.slice(0, 10)}…`);
           break;
+        }
+        if (status.status === "FAILED") {
+          // FE-049: preserve failure context for debugging
+          const errorDetail = (status as any).resultXdr ?? "unknown";
+          throw new Error(`Transaction failed. Result XDR: ${errorDetail}`);
         }
         attempts++;
       }
@@ -316,9 +331,12 @@ export default function WasmRegistryPage() {
 
   return (
     <div className="container mx-auto space-y-8 p-6">
-      <div>
-        <h1 className="text-3xl font-bold tracking-tight">WASM Registry</h1>
-        <p className="text-muted-foreground">Upload, manage, and deploy contract code.</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">WASM Registry</h1>
+          <p className="text-muted-foreground">Upload, manage, and deploy contract code.</p>
+        </div>
+        <InstantiateWizard />
       </div>
 
       <div className="grid grid-cols-1 gap-8 lg:grid-cols-3">

--- a/apps/web/components/instantiate-wizard.tsx
+++ b/apps/web/components/instantiate-wizard.tsx
@@ -1,0 +1,312 @@
+"use client";
+
+import { useState } from "react";
+import {
+  TransactionBuilder,
+  TimeoutInfinite,
+  Operation,
+  Address,
+} from "@stellar/stellar-sdk";
+import { Server as SorobanServer } from "@stellar/stellar-sdk/rpc";
+import { signTransaction } from "@stellar/freighter-api";
+import { Wand2, Loader2, ChevronRight, ChevronLeft, CheckCircle2 } from "lucide-react";
+import { Button } from "@devconsole/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@devconsole/ui";
+import { Input } from "@devconsole/ui";
+import { Label } from "@devconsole/ui";
+import { Badge } from "@devconsole/ui";
+import { toast } from "sonner";
+import { useWallet } from "@/store/useWallet";
+import { useNetworkStore } from "@/store/useNetworkStore";
+import { useWasmStore, type WasmEntry } from "@/store/useWasmStore";
+import { useContractStore } from "@/store/useContractStore";
+import { useWorkspaceStore } from "@/store/useWorkspaceStore";
+import { extractContractIdFromDeployResult } from "@devconsole/soroban-utils";
+
+type Step = "select" | "configure" | "confirm" | "done";
+
+interface InstantiateWizardProps {
+  /** Pre-select a specific WASM hash */
+  preselectedHash?: string;
+}
+
+export function InstantiateWizard({ preselectedHash }: InstantiateWizardProps) {
+  const { isConnected, address } = useWallet();
+  const { getActiveNetworkConfig } = useNetworkStore();
+  const { wasms, associateContract, pinArtifact } = useWasmStore();
+  const { addContract } = useContractStore();
+  const { activeWorkspaceId, attachArtifact } = useWorkspaceStore();
+
+  const [open, setOpen] = useState(false);
+  const [step, setStep] = useState<Step>("select");
+  const [selectedHash, setSelectedHash] = useState(preselectedHash ?? "");
+  const [salt, setSalt] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [resultContractId, setResultContractId] = useState<string | null>(null);
+
+  const selectedEntry: WasmEntry | undefined = wasms.find((w) => w.hash === selectedHash);
+
+  const reset = () => {
+    setStep("select");
+    setSelectedHash(preselectedHash ?? "");
+    setSalt("");
+    setResultContractId(null);
+  };
+
+  const handleOpen = (v: boolean) => {
+    setOpen(v);
+    if (!v) reset();
+  };
+
+  const handleInstantiate = async () => {
+    if (!address || !isConnected || !selectedHash) return;
+    setBusy(true);
+    try {
+      const network = getActiveNetworkConfig();
+      const server = new SorobanServer(network.rpcUrl);
+      const sourceAccount = await server.getAccount(address);
+
+      const saltBytes = salt
+        ? Buffer.from(salt.padEnd(32, "\0").slice(0, 32))
+        : Buffer.alloc(32).fill(Math.floor(Math.random() * 255));
+
+      const tx = new TransactionBuilder(sourceAccount, {
+        fee: "10000",
+        networkPassphrase: network.networkPassphrase,
+      })
+        .addOperation(
+          Operation.createCustomContract({
+            wasmHash: Buffer.from(selectedHash, "hex"),
+            address: new Address(address),
+            salt: saltBytes,
+          }),
+        )
+        .setTimeout(TimeoutInfinite)
+        .build();
+
+      const preparedTx = await server.prepareTransaction(tx);
+      const signedXdr = await signTransaction(preparedTx.toXDR(), {
+        networkPassphrase: network.networkPassphrase,
+      });
+
+      const res = await server.sendTransaction(
+        TransactionBuilder.fromXDR(signedXdr.signedTxXdr, network.networkPassphrase),
+      );
+
+      if (res.status !== "PENDING") throw new Error("Submission failed");
+
+      let contractId: string | null = null;
+      for (let i = 0; i < 10; i++) {
+        await new Promise((r) => setTimeout(r, 2000));
+        const status = await server.getTransaction(res.hash);
+        if (status.status === "SUCCESS") {
+          contractId = status.resultMetaXdr
+            ? extractContractIdFromDeployResult(status.resultMetaXdr)
+            : null;
+          break;
+        }
+        if (status.status === "FAILED") throw new Error("Transaction failed");
+      }
+
+      const finalId = contractId ?? res.hash;
+      const relationship = contractId ? "confirmed" : "inferred";
+
+      associateContract(selectedHash, finalId, relationship);
+      pinArtifact(selectedHash, activeWorkspaceId);
+      attachArtifact(activeWorkspaceId, { kind: "wasm", id: selectedHash, contractId: finalId, relationship });
+      addContract(finalId, network.id);
+
+      setResultContractId(finalId);
+      setStep("done");
+      toast.success("Contract instantiated!");
+    } catch (e: any) {
+      toast.error(`Instantiation failed: ${e.message}`);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm" disabled={!isConnected}>
+          <Wand2 className="mr-2 h-4 w-4" />
+          Instantiate Wizard
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Wand2 className="h-5 w-5" />
+            Contract Instantiation Wizard
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Step indicator */}
+        <div className="flex items-center gap-1 text-xs text-muted-foreground">
+          {(["select", "configure", "confirm", "done"] as Step[]).map((s, i) => (
+            <span key={s} className="flex items-center gap-1">
+              <span className={step === s ? "font-semibold text-foreground" : ""}>{s}</span>
+              {i < 3 && <ChevronRight className="h-3 w-3" />}
+            </span>
+          ))}
+        </div>
+
+        {/* Step: select */}
+        {step === "select" && (
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              Choose a stored WASM artifact to instantiate.
+            </p>
+            {wasms.length === 0 ? (
+              <p className="rounded-md border border-dashed p-4 text-center text-sm text-muted-foreground">
+                No WASM artifacts found. Upload one first.
+              </p>
+            ) : (
+              <div className="max-h-60 space-y-2 overflow-y-auto">
+                {wasms.map((w) => (
+                  <button
+                    key={w.hash}
+                    onClick={() => setSelectedHash(w.hash)}
+                    className={`w-full rounded-md border p-3 text-left transition-colors hover:bg-muted/50 ${
+                      selectedHash === w.hash ? "border-primary bg-primary/5" : ""
+                    }`}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{w.name}</span>
+                      <Badge variant="outline" className="text-[10px]">
+                        v{w.version}
+                      </Badge>
+                    </div>
+                    <p className="mt-0.5 font-mono text-[11px] text-muted-foreground">
+                      {w.hash.slice(0, 16)}…
+                    </p>
+                    <div className="mt-1 flex gap-1">
+                      <Badge variant="secondary" className="text-[10px]">{w.network}</Badge>
+                      {w.deployedContractId && (
+                        <Badge className="text-[10px]">deployed</Badge>
+                      )}
+                    </div>
+                  </button>
+                ))}
+              </div>
+            )}
+            <div className="flex justify-end">
+              <Button
+                size="sm"
+                disabled={!selectedHash}
+                onClick={() => setStep("configure")}
+              >
+                Next <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step: configure */}
+        {step === "configure" && selectedEntry && (
+          <div className="space-y-4">
+            <div className="rounded-md border bg-muted/30 p-3 text-sm">
+              <p className="font-medium">{selectedEntry.name}</p>
+              <p className="font-mono text-xs text-muted-foreground">{selectedEntry.hash.slice(0, 20)}…</p>
+            </div>
+
+            {selectedEntry.functions && selectedEntry.functions.length > 0 && (
+              <div>
+                <Label className="text-xs">Exported Functions</Label>
+                <div className="mt-1 flex flex-wrap gap-1">
+                  {selectedEntry.functions.map((fn) => (
+                    <Badge key={fn} variant="secondary" className="text-[10px]">{fn}()</Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-1">
+              <Label htmlFor="salt">Salt (optional, 32-char max)</Label>
+              <Input
+                id="salt"
+                placeholder="Leave blank for random salt"
+                value={salt}
+                maxLength={32}
+                onChange={(e) => setSalt(e.target.value)}
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Using the same salt + deployer address produces the same contract ID.
+              </p>
+            </div>
+
+            <div className="flex justify-between">
+              <Button size="sm" variant="outline" onClick={() => setStep("select")}>
+                <ChevronLeft className="mr-1 h-4 w-4" /> Back
+              </Button>
+              <Button size="sm" onClick={() => setStep("confirm")}>
+                Next <ChevronRight className="ml-1 h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step: confirm */}
+        {step === "confirm" && selectedEntry && (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">Review and confirm instantiation.</p>
+            <div className="space-y-2 rounded-md border bg-muted/30 p-3 text-sm">
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Artifact</span>
+                <span className="font-medium">{selectedEntry.name} v{selectedEntry.version}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Network</span>
+                <Badge variant="outline" className="text-[10px]">{selectedEntry.network}</Badge>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Salt</span>
+                <span className="font-mono text-xs">{salt || "(random)"}</span>
+              </div>
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Deployer</span>
+                <span className="font-mono text-xs">{address?.slice(0, 10)}…</span>
+              </div>
+            </div>
+            <div className="flex justify-between">
+              <Button size="sm" variant="outline" onClick={() => setStep("configure")}>
+                <ChevronLeft className="mr-1 h-4 w-4" /> Back
+              </Button>
+              <Button size="sm" onClick={handleInstantiate} disabled={busy}>
+                {busy ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : null}
+                {busy ? "Instantiating…" : "Instantiate"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step: done */}
+        {step === "done" && (
+          <div className="space-y-4 text-center">
+            <CheckCircle2 className="mx-auto h-12 w-12 text-green-500" />
+            <p className="font-semibold">Contract Instantiated!</p>
+            {resultContractId && (
+              <p className="break-all rounded-md border bg-muted/30 p-2 font-mono text-xs">
+                {resultContractId}
+              </p>
+            )}
+            <p className="text-sm text-muted-foreground">
+              The contract has been linked to your workspace.
+            </p>
+            <Button size="sm" onClick={() => handleOpen(false)}>
+              Close
+            </Button>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/store/useWasmStore.ts
+++ b/apps/web/store/useWasmStore.ts
@@ -6,11 +6,8 @@ import { persist } from "zustand/middleware";
 export type ProvenanceRelationship = "inferred" | "confirmed";
 
 export interface ProvenanceNode {
-  /** The WASM hash this node belongs to */
   wasmHash: string;
-  /** Contract instance ID produced by deploying this WASM */
   contractId: string;
-  /** How the link was established */
   relationship: ProvenanceRelationship;
   network: string;
   deployedAt: number;
@@ -20,33 +17,56 @@ export interface ProvenanceNode {
 
 export interface WasmEntry {
   hash: string;
+  /** FE-050: canonical name shared across versions */
   name: string;
+  /** FE-050: semver-style version tag, e.g. "1.0.0" */
+  version: string;
   network: string;
   installedAt: number;
   functions?: string[];
-  /** Contract ID associated after a successful deploy */
   deployedContractId?: string;
   deployedAt?: number;
-  /** Workspace context at upload time */
   workspaceId?: string;
-  /** Whether the last parse attempt failed */
   parseError?: boolean;
-  /** SC-003: Provenance nodes linking this WASM to deployed contract instances */
   provenance?: ProvenanceNode[];
+  /** FE-050: IDs of workspaces / deployments that pin this artifact */
+  pinnedBy?: string[];
 }
 
 // ── Store ─────────────────────────────────────────────────────────────────────
 
 interface WasmState {
   wasms: WasmEntry[];
-  addWasm: (entry: WasmEntry) => void;
+  addWasm: (entry: Omit<WasmEntry, "version"> & { version?: string }) => void;
   removeWasm: (hash: string) => void;
   associateContract: (hash: string, contractId: string, relationship?: ProvenanceRelationship) => void;
-  /** SC-003: Add a provenance node to a WASM entry */
   addProvenanceNode: (node: ProvenanceNode) => void;
-  /** SC-003: Get all provenance nodes for a given WASM hash */
   getProvenance: (hash: string) => ProvenanceNode[];
+  /** FE-050: pin an artifact so retention rules won't auto-remove it */
+  pinArtifact: (hash: string, pinnedById: string) => void;
+  /** FE-050: unpin an artifact */
+  unpinArtifact: (hash: string, pinnedById: string) => void;
+  /** FE-050: remove entries that are not pinned and older than maxAgeMs */
+  pruneUnpinned: (maxAgeMs?: number) => void;
 }
+
+/** FE-050: derive the next version for a given artifact name */
+function nextVersion(existing: WasmEntry[], name: string): string {
+  const versions = existing
+    .filter((w) => w.name === name)
+    .map((w) => {
+      const parts = w.version.split(".").map(Number);
+      return parts[0] * 1_000_000 + (parts[1] ?? 0) * 1_000 + (parts[2] ?? 0);
+    });
+  if (versions.length === 0) return "1.0.0";
+  const max = Math.max(...versions);
+  const major = Math.floor(max / 1_000_000);
+  const minor = Math.floor((max % 1_000_000) / 1_000);
+  const patch = max % 1_000;
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+const DEFAULT_RETENTION_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 
 export const useWasmStore = create<WasmState>()(
   persist(
@@ -55,36 +75,58 @@ export const useWasmStore = create<WasmState>()(
 
       addWasm: (entry) =>
         set((state) => {
-          const existing = state.wasms.find((w) => w.hash === entry.hash);
+          // FE-050: deduplication — same binary hash on same network is a no-op update
+          const existing = state.wasms.find(
+            (w) => w.hash === entry.hash && w.network === entry.network,
+          );
           if (existing) {
             return {
               wasms: state.wasms.map((w) =>
-                w.hash === entry.hash
-                  ? { ...w, name: entry.name, network: entry.network, functions: entry.functions ?? w.functions }
+                w.hash === entry.hash && w.network === entry.network
+                  ? {
+                      ...w,
+                      name: entry.name,
+                      functions: entry.functions ?? w.functions,
+                      workspaceId: entry.workspaceId ?? w.workspaceId,
+                    }
                   : w,
               ),
             };
           }
-          return { wasms: [entry, ...state.wasms] };
+
+          // FE-050: same name → bump version; new name → 1.0.0
+          const version = entry.version ?? nextVersion(state.wasms, entry.name);
+          return { wasms: [{ ...entry, version }, ...state.wasms] };
         }),
 
       removeWasm: (hash) =>
-        set((state) => ({
-          wasms: state.wasms.filter((w) => w.hash !== hash),
-        })),
+        set((state) => {
+          const entry = state.wasms.find((w) => w.hash === hash);
+          // FE-050: retention — refuse to remove pinned artifacts
+          if (entry && (entry.pinnedBy?.length ?? 0) > 0) return state;
+          return { wasms: state.wasms.filter((w) => w.hash !== hash) };
+        }),
 
       associateContract: (hash, contractId, relationship = "confirmed") =>
         set((state) => ({
           wasms: state.wasms.map((w) => {
             if (w.hash !== hash) return w;
             const now = Date.now();
-            const network = w.network;
-            const node: ProvenanceNode = { wasmHash: hash, contractId, relationship, network, deployedAt: now };
+            const node: ProvenanceNode = {
+              wasmHash: hash,
+              contractId,
+              relationship,
+              network: w.network,
+              deployedAt: now,
+            };
             return {
               ...w,
               deployedContractId: contractId,
               deployedAt: now,
-              provenance: [...(w.provenance ?? []).filter((p) => p.contractId !== contractId), node],
+              provenance: [
+                ...(w.provenance ?? []).filter((p) => p.contractId !== contractId),
+                node,
+              ],
             };
           }),
         })),
@@ -95,7 +137,10 @@ export const useWasmStore = create<WasmState>()(
             w.hash === node.wasmHash
               ? {
                   ...w,
-                  provenance: [...(w.provenance ?? []).filter((p) => p.contractId !== node.contractId), node],
+                  provenance: [
+                    ...(w.provenance ?? []).filter((p) => p.contractId !== node.contractId),
+                    node,
+                  ],
                 }
               : w,
           ),
@@ -104,6 +149,36 @@ export const useWasmStore = create<WasmState>()(
       getProvenance: (hash) => {
         const entry = get().wasms.find((w) => w.hash === hash);
         return entry?.provenance ?? [];
+      },
+
+      pinArtifact: (hash, pinnedById) =>
+        set((state) => ({
+          wasms: state.wasms.map((w) =>
+            w.hash === hash
+              ? { ...w, pinnedBy: [...new Set([...(w.pinnedBy ?? []), pinnedById])] }
+              : w,
+          ),
+        })),
+
+      unpinArtifact: (hash, pinnedById) =>
+        set((state) => ({
+          wasms: state.wasms.map((w) =>
+            w.hash === hash
+              ? { ...w, pinnedBy: (w.pinnedBy ?? []).filter((id) => id !== pinnedById) }
+              : w,
+          ),
+        })),
+
+      pruneUnpinned: (maxAgeMs = DEFAULT_RETENTION_MS) => {
+        const cutoff = Date.now() - maxAgeMs;
+        set((state) => ({
+          wasms: state.wasms.filter(
+            (w) =>
+              (w.pinnedBy?.length ?? 0) > 0 ||
+              w.deployedContractId !== undefined ||
+              w.installedAt > cutoff,
+          ),
+        }));
       },
     }),
     { name: "soroban-wasm-storage" },

--- a/packages/soroban-utils/src/xdr-utils.ts
+++ b/packages/soroban-utils/src/xdr-utils.ts
@@ -1,4 +1,4 @@
-import { xdr } from "@stellar/stellar-sdk";
+import { xdr, StrKey } from "@stellar/stellar-sdk";
 import ScVal from "@stellar/stellar-sdk";
 import TransactionEnvelope from "@stellar/stellar-sdk";
 
@@ -24,5 +24,34 @@ export function encodeJsonToXdr(jsonString: string, type: XdrType): string {
     }
   } catch (error: any) {
     throw new Error(`Encoding failed: ${error.message}`);
+  }
+}
+
+/**
+ * FE-049: Extract the real contract ID from a successful deploy transaction's
+ * result XDR. The Soroban host returns the new contract address as an ScAddress
+ * inside the transaction's return value.
+ *
+ * @param resultMetaXdr - base64-encoded TransactionMeta XDR from getTransaction
+ * @returns Strkey-encoded contract ID (C…) or null if not found
+ */
+export function extractContractIdFromDeployResult(resultMetaXdr: string): string | null {
+  try {
+    const meta = xdr.TransactionMeta.fromXDR(resultMetaXdr, "base64");
+    // v3 meta carries sorobanMeta with the return value
+    const sorobanMeta = meta.v3().sorobanMeta();
+    if (!sorobanMeta) return null;
+
+    const returnValue = sorobanMeta.returnValue();
+    // The return value of createCustomContract is ScVal::Address
+    if (returnValue.switch().name !== "scvAddress") return null;
+
+    const scAddress = returnValue.address();
+    if (scAddress.switch().name !== "scAddressTypeContract") return null;
+
+    const contractIdBytes = scAddress.contractId();
+    return StrKey.encodeContract(contractIdBytes);
+  } catch {
+    return null;
   }
 }


### PR DESCRIPTION
## Summary

Implements all four issues assigned to Tinna23 in a single PR.

---

### FE-049 — Fix deployment result decoding and extract real contract IDs
- `extractContractIdFromDeployResult()` in `xdr-utils.ts` decodes the Soroban host return value (`ScVal::Address`) from `TransactionMeta v3`
- Deploy flow records the real contract ID when available, falls back to tx hash with `inferred` relationship
- Failure path preserves `resultXdr` for debugging/retry context

### FE-050 — WASM registry versioning, deduplication, and retention rules
- `WasmEntry` gains `version` (semver) and `pinnedBy` fields
- `addWasm` deduplicates same hash+network; bumps patch version for same artifact name
- `removeWasm` blocks deletion of pinned artifacts
- New actions: `pinArtifact`, `unpinArtifact`, `pruneUnpinned` (30-day default retention)

### FE-051 — Contract instantiation wizard
- `InstantiateWizard` component: select → configure → confirm → done multi-step flow
- Driven by stored WASM artifacts and their exported function metadata
- Successful instantiation links contract into workspace state and pins the artifact

### FE-052 — Modernize account dashboard
- Loads real balances, sequence number, signers, and thresholds via Horizon SDK
- Recent activity table with op-type icons and network-aware explorer links
- Fund button and developer tools only shown on testnet/futurenet
- Graceful disconnected and account-not-found states with helpful guidance

## Files Changed
- `packages/soroban-utils/src/xdr-utils.ts`
- `apps/web/store/useWasmStore.ts`
- `apps/web/app/deploy/wasm/page.tsx`
- `apps/web/components/instantiate-wizard.tsx` *(new)*
- `apps/web/app/account/page.tsx`

Closes #197
Closes #198
Closes #199
Closes #200