### PR TITLE
feat(web): implement FE-053 to FE-056 assigned tasks

### DIFF
--- a/apps/web/app/account/page.tsx
+++ b/apps/web/app/account/page.tsx
@@ -31,6 +31,7 @@ import {
 import { useWallet } from "@/store/useWallet";
 import { useNetworkStore } from "@/store/useNetworkStore";
 import { FundAccountButton } from "@/components/fund-account-button";
+import { canFundWithProvider } from "@/lib/funding";
 
 interface AssetBalance {
   asset_type: string;
@@ -121,7 +122,7 @@ function DisconnectedState() {
 
 export default function AccountDashboard() {
   const { isConnected, address } = useWallet();
-  const { getActiveNetworkConfig, currentNetwork } = useNetworkStore();
+  const { getActiveNetworkConfig, currentNetwork, getFundingProvider } = useNetworkStore();
 
   const [accountData, setAccountData] = useState<AccountData | null>(null);
   const [recentOps, setRecentOps] = useState<RecentOp[]>([]);
@@ -195,8 +196,7 @@ export default function AccountDashboard() {
   const xlmBalance = accountData?.balances.find((b) => b.asset_type === "native");
   const trustlines = accountData?.balances.filter((b) => b.asset_type !== "native") ?? [];
 
-  // FE-052: network-aware capabilities
-  const isTestnetLike = currentNetwork === "testnet" || currentNetwork === "futurenet";
+  const canFund = canFundWithProvider(getFundingProvider());
   const explorerBase =
     currentNetwork === "mainnet"
       ? "https://stellar.expert/explorer/public/tx"
@@ -218,8 +218,7 @@ export default function AccountDashboard() {
         </div>
 
         <div className="flex flex-wrap items-center gap-2">
-          {/* FE-052: only show fund button on test networks */}
-          {isTestnetLike && <FundAccountButton />}
+          {canFund && <FundAccountButton />}
           <Button onClick={fetchAccountData} disabled={loading} variant="outline" size="sm">
             <RefreshCw className={`mr-2 h-4 w-4 ${loading ? "animate-spin" : ""}`} />
             Refresh
@@ -234,10 +233,10 @@ export default function AccountDashboard() {
           <AlertTitle>Error Loading Account</AlertTitle>
           <AlertDescription className="space-y-2">
             <p>{error}</p>
-            {error.includes("not found") && isTestnetLike && (
+            {error.includes("not found") && canFund && (
               <div className="mt-3 rounded-md border border-destructive/20 bg-destructive/10 p-3">
                 <p className="text-sm font-medium text-foreground">
-                  💡 Click <strong className="text-blue-500">"Get Testnet XLM"</strong> to fund
+                  Click <strong className="text-blue-500">"Fund Account"</strong> to fund
                   and create this account instantly.
                 </p>
               </div>
@@ -463,7 +462,7 @@ export default function AccountDashboard() {
               <span className="font-mono text-sm">{accountData.balances.length}</span>
             </div>
             {/* FE-052: network-aware developer tools */}
-            {isTestnetLike && (
+            {canFund && (
               <div className="flex justify-between rounded-lg bg-blue-500/10 p-3">
                 <span className="text-sm font-medium text-blue-700">Developer Tools</span>
                 <div className="flex gap-2">

--- a/apps/web/app/contracts/page.tsx
+++ b/apps/web/app/contracts/page.tsx
@@ -2,7 +2,16 @@
 
 import { useEffect, useState } from "react";
 import { useContractStore } from "@/store/useContractStore";
-import { Trash2, Plus, Search, FileCode, FlaskConical } from "lucide-react";
+import {
+  Trash2,
+  Plus,
+  Search,
+  FileCode,
+  FlaskConical,
+  BookmarkPlus,
+  Star,
+  Wrench,
+} from "lucide-react";
 import { Button } from "@devconsole/ui";
 import { Input } from "@devconsole/ui";
 import Link from "next/link";
@@ -23,13 +32,25 @@ import {
 } from "@devconsole/ui";
 import { toast } from "sonner";
 import { getDeployedFixtures } from "@/lib/fixture-manifest";
+import { useWorkspaceStore } from "@/store/useWorkspaceStore";
+import { useNetworkStore } from "@/store/useNetworkStore";
 
 export default function ContractsPage() {
   const { contracts, addContract, removeContract } = useContractStore();
+  const { currentNetwork } = useNetworkStore();
+  const {
+    activeWorkspaceId,
+    bookmarkContract,
+    getContractBookmarks,
+    toggleBookmarkFavorite,
+    removeContractBookmark,
+    repairBookmarkNetwork,
+  } = useWorkspaceStore();
   const [inputVal, setInputVal] = useState("");
   const [error, setError] = useState("");
   const [isMounted, setIsMounted] = useState(false);
   const fixtures = getDeployedFixtures();
+  const bookmarks = getContractBookmarks(activeWorkspaceId);
 
   useEffect(() => {
     setIsMounted(true);
@@ -48,10 +69,11 @@ export default function ContractsPage() {
       return;
     }
 
-    addContract(id, "testnet");
+    addContract(id, currentNetwork);
+    bookmarkContract(activeWorkspaceId, id, currentNetwork, "manual");
     setInputVal("");
     setError("");
-    toast.success("Contract added successfully!");
+    toast.success("Contract added and bookmarked.");
   };
 
   if (!isMounted) return null;
@@ -142,17 +164,35 @@ export default function ContractsPage() {
                     {new Date(contract.addedAt).toLocaleDateString()}
                   </TableCell>
                   <TableCell className="text-right">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => {
-                        removeContract(contract.id);
-                        toast.success("Contract removed");
-                      }}
-                      className="text-muted-foreground hover:text-red-500"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                    <div className="flex justify-end gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          bookmarkContract(
+                            activeWorkspaceId,
+                            contract.id,
+                            contract.network,
+                            "contracts-page",
+                          );
+                          toast.success("Contract bookmarked");
+                        }}
+                        className="text-muted-foreground hover:text-blue-500"
+                      >
+                        <BookmarkPlus className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => {
+                          removeContract(contract.id);
+                          toast.success("Contract removed");
+                        }}
+                        className="text-muted-foreground hover:text-red-500"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
                   </TableCell>
                 </TableRow>
               ))
@@ -196,6 +236,12 @@ export default function ContractsPage() {
                     className="shrink-0"
                     onClick={() => {
                       addContract(f.contractId!, f.network);
+                      bookmarkContract(
+                        activeWorkspaceId,
+                        f.contractId!,
+                        f.network,
+                        "fixture",
+                      );
                       toast.success(`${f.label} added`);
                     }}
                     disabled={contracts.some((c) => c.id === f.contractId)}
@@ -209,6 +255,96 @@ export default function ContractsPage() {
           </CardContent>
         </Card>
       )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Bookmarked Contracts</CardTitle>
+          <CardDescription>
+            Favorites stay pinned at the top. Stale bookmarks can be repaired.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {bookmarks.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No bookmarks yet. Bookmark a contract from this page.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {bookmarks.map((bookmark) => {
+                const isStale = !contracts.some(
+                  (contract) =>
+                    contract.id === bookmark.contractId &&
+                    contract.network === bookmark.networkId,
+                );
+
+                return (
+                  <div
+                    key={bookmark.id}
+                    className="flex items-center justify-between rounded-md border p-3"
+                  >
+                    <div className="min-w-0">
+                      <Link
+                        href={`/contracts/${bookmark.contractId}`}
+                        className="truncate font-mono text-xs hover:text-blue-500 hover:underline"
+                      >
+                        {bookmark.contractId}
+                      </Link>
+                      <div className="text-xs text-muted-foreground">
+                        {bookmark.networkId} · source: {bookmark.source}
+                        {isStale ? " · stale" : ""}
+                      </div>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() =>
+                          toggleBookmarkFavorite(activeWorkspaceId, bookmark.id)
+                        }
+                        className={
+                          bookmark.favorite
+                            ? "text-amber-500"
+                            : "text-muted-foreground"
+                        }
+                      >
+                        <Star className="h-4 w-4" />
+                      </Button>
+                      {isStale && (
+                        <Button
+                          size="icon"
+                          variant="ghost"
+                          onClick={() => {
+                            addContract(bookmark.contractId, bookmark.networkId);
+                            repairBookmarkNetwork(
+                              activeWorkspaceId,
+                              bookmark.id,
+                              bookmark.networkId,
+                            );
+                            toast.success("Bookmark repaired");
+                          }}
+                          className="text-blue-600"
+                        >
+                          <Wrench className="h-4 w-4" />
+                        </Button>
+                      )}
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() =>
+                          removeContractBookmark(activeWorkspaceId, bookmark.id)
+                        }
+                        className="text-red-500"
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 }

--- a/apps/web/app/tx-builder/page.tsx
+++ b/apps/web/app/tx-builder/page.tsx
@@ -13,6 +13,7 @@ import {
   SlidersHorizontal,
   Terminal,
   Eye,
+  Download,
 } from "lucide-react";
 import { Server as SorobanServer } from "@stellar/stellar-sdk/rpc";
 import { useMemo, useState } from "react";
@@ -25,6 +26,7 @@ import { ActionGuard } from "@/components/action-guard";
 import { convertToScVal, type NormalizedSimulationResult } from "@devconsole/soroban-utils";
 import { useNetworkStore } from "@/store/useNetworkStore";
 import { SavedCall, useSavedCallsStore } from "@/store/useSavedCallsStore";
+import { useResultBundlesStore } from "@/store/useResultBundlesStore";
 import { useWallet } from "@/store/useWallet";
 import { Alert, AlertDescription } from "@devconsole/ui";
 import { Badge } from "@devconsole/ui";
@@ -38,6 +40,7 @@ import {
 } from "@devconsole/ui";
 import { Input } from "@devconsole/ui";
 import { Label } from "@devconsole/ui";
+import { exportResultBundle } from "@/lib/result-bundles";
 
 type SimulationSummary = {
   operationCount: number;
@@ -88,6 +91,7 @@ export default function TxBuilderPage() {
   const pathname = usePathname();
   const { savedCalls, cartItems, addToCart, removeFromCart, moveCartItem, clearCart } =
     useSavedCallsStore();
+  const { addBundle } = useResultBundlesStore();
   const { getActiveNetworkConfig, currentNetwork } = useNetworkStore();
   const { isConnected, address, isSandboxMode, enterSandbox, exitSandbox } = useWallet();
 
@@ -191,6 +195,17 @@ export default function TxBuilderPage() {
       const normalized = await simulateTx(txXdr, network);
       if (!normalized.ok) throw new Error(normalized.error || "Unknown simulation error");
 
+      addBundle({
+        kind: "batch",
+        title: "Batch simulation",
+        networkId: network.id,
+        payload: {
+          operationCount: cartItems.length,
+          cartItems,
+          simulation: normalized,
+        },
+      });
+
       setSimulation({ operationCount: cartItems.length, details: normalized });
       setResult("Simulation success for batched transaction.");
       toast.success("Simulation success");
@@ -249,6 +264,20 @@ export default function TxBuilderPage() {
         setSimulation({ operationCount: cartItems.length, details: txResult.simulation });
       }
 
+      addBundle({
+        kind: "batch",
+        title: "Batch submission",
+        networkId: network.id,
+        txHash: txResult.hash,
+        payload: {
+          operationCount: cartItems.length,
+          cartItems,
+          status: txResult.status,
+          simulation: txResult.simulation,
+          errorMessage: txResult.errorMessage,
+        },
+      });
+
       if (txResult.status === "success") {
         setResult(`Transaction submitted. Hash: ${txResult.hash}`);
         clearCart();
@@ -262,6 +291,24 @@ export default function TxBuilderPage() {
     } finally {
       setIsLoading(false);
     }
+  };
+
+  const handleExportBundle = () => {
+    const network = getActiveNetworkConfig();
+    const bundle = addBundle({
+      kind: "batch",
+      title: "Batch manual export",
+      networkId: network.id,
+      payload: {
+        operationCount: cartItems.length,
+        cartItems,
+        simulation,
+        result,
+        opErrors,
+      },
+    });
+    exportResultBundle(bundle);
+    toast.success("Batch result bundle exported");
   };
 
   return (
@@ -460,6 +507,12 @@ export default function TxBuilderPage() {
                 Sign &amp; Submit
               </Button>
             </ActionGuard>
+            {(simulation || result) && (
+              <Button variant="outline" onClick={handleExportBundle}>
+                <Download className="mr-2 h-4 w-4" />
+                Export Bundle
+              </Button>
+            )}
           </div>
         </CardContent>
       </Card>

--- a/apps/web/components/command-palette.tsx
+++ b/apps/web/components/command-palette.tsx
@@ -3,9 +3,11 @@
 import { Command } from "cmdk";
 import {
   Briefcase,
+  Bookmark,
   FileCode,
   Globe,
   Search,
+  Star,
   Terminal,
   Zap,
   Clock,
@@ -22,7 +24,13 @@ import { useSavedCallsStore } from "@/store/useSavedCallsStore";
 
 // ── FE-030: Global search index types ────────────────────────────────────────
 
-type SearchItemKind = "workspace" | "contract" | "saved-call" | "artifact" | "nav";
+type SearchItemKind =
+  | "workspace"
+  | "contract"
+  | "saved-call"
+  | "bookmark"
+  | "artifact"
+  | "nav";
 
 interface SearchItem {
   id: string;
@@ -61,7 +69,14 @@ export function CommandPalette() {
   const [recentIds, setRecentIds] = useState<string[]>([]);
 
   const router = useRouter();
-  const { workspaces, setActiveWorkspace } = useWorkspaceStore();
+  const {
+    workspaces,
+    setActiveWorkspace,
+    activeWorkspaceId,
+    bookmarkContract,
+    getContractBookmarks,
+    toggleBookmarkFavorite,
+  } = useWorkspaceStore();
   const { currentNetwork, setNetwork } = useNetworkStore();
   const { contracts } = useContractStore();
   const { savedCalls } = useSavedCallsStore();
@@ -114,7 +129,42 @@ export function CommandPalette() {
         kind: "contract",
         label: c.name,
         sublabel: `${c.network} · ${c.id.slice(0, 8)}…`,
-        onSelect: () => router.push(`/contract/${c.id}`),
+        onSelect: () => router.push(`/contracts/${c.id}`),
+      });
+      items.push({
+        id: `contract-bookmark:${c.id}`,
+        kind: "bookmark",
+        label: `Bookmark ${c.name}`,
+        sublabel: `${c.network} · quick action`,
+        onSelect: () => {
+          bookmarkContract(activeWorkspaceId, c.id, c.network, "command-palette");
+          toast.success("Contract bookmarked");
+        },
+      });
+    }
+
+    // Contract bookmarks
+    for (const bookmark of getContractBookmarks(activeWorkspaceId)) {
+      items.push({
+        id: `bookmark:${bookmark.id}`,
+        kind: "bookmark",
+        label: bookmark.contractId,
+        sublabel: `${bookmark.networkId} · ${bookmark.source}${
+          bookmark.favorite ? " · favorite" : ""
+        }`,
+        onSelect: () => router.push(`/contracts/${bookmark.contractId}`),
+      });
+      items.push({
+        id: `bookmark-favorite:${bookmark.id}`,
+        kind: "bookmark",
+        label: bookmark.favorite
+          ? `Unfavorite ${bookmark.contractId.slice(0, 8)}…`
+          : `Favorite ${bookmark.contractId.slice(0, 8)}…`,
+        sublabel: "Toggle bookmark favorite",
+        onSelect: () => {
+          toggleBookmarkFavorite(activeWorkspaceId, bookmark.id);
+          toast.success("Bookmark updated");
+        },
       });
     }
 
@@ -161,7 +211,17 @@ export function CommandPalette() {
     );
 
     return items;
-  }, [workspaces, contracts, savedCalls, router, setActiveWorkspace]);
+  }, [
+    workspaces,
+    contracts,
+    savedCalls,
+    router,
+    setActiveWorkspace,
+    activeWorkspaceId,
+    bookmarkContract,
+    getContractBookmarks,
+    toggleBookmarkFavorite,
+  ]);
 
   // Filter by search query
   const filtered = useMemo(() => {
@@ -184,6 +244,7 @@ export function CommandPalette() {
     workspace: <Briefcase className="mr-2 h-4 w-4 text-muted-foreground" />,
     contract: <FileCode className="mr-2 h-4 w-4 text-muted-foreground" />,
     "saved-call": <Terminal className="mr-2 h-4 w-4 text-muted-foreground" />,
+    bookmark: <Bookmark className="mr-2 h-4 w-4 text-muted-foreground" />,
     artifact: <Box className="mr-2 h-4 w-4 text-muted-foreground" />,
     nav: <Zap className="mr-2 h-4 w-4 text-muted-foreground" />,
   };
@@ -192,6 +253,7 @@ export function CommandPalette() {
     workspace: "Workspaces",
     contract: "Contracts",
     "saved-call": "Saved Calls",
+    bookmark: "Bookmarks",
     artifact: "Artifacts",
     nav: "Navigation",
   };

--- a/apps/web/components/contract-call-form.tsx
+++ b/apps/web/components/contract-call-form.tsx
@@ -20,6 +20,7 @@ import {
   SlidersHorizontal,
   Eye,
   AlertCircle,
+  Download,
 } from "lucide-react";
 import { usePathname } from "next/navigation";
 import { useWallet } from "@/store/useWallet";
@@ -68,6 +69,8 @@ import {
 } from "@devconsole/ui";
 import { ActionGuard } from "./action-guard";
 import { toast } from "sonner";
+import { useResultBundlesStore } from "@/store/useResultBundlesStore";
+import { exportResultBundle } from "@/lib/result-bundles";
 
 interface ContractCallFormProps {
   contractId: string;
@@ -151,7 +154,8 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
   const [result, setResult] = useState<string | null>(null);
   const [simulation, setSimulation] =
     useState<NormalizedSimulationResult | null>(null);
-  const { saveCall } = useSavedCallsStore();
+  const { saveCall, savePreset } = useSavedCallsStore();
+  const { addBundle } = useResultBundlesStore();
   const { activeWorkspaceId, linkSavedCall } = useWorkspaceStore();
   const [isSaveOpen, setIsSaveOpen] = useState(false);
   const [saveName, setSaveName] = useState("");
@@ -272,6 +276,20 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
       const normalized = normalizeSimulationResult(sim);
       setSimulation(normalized);
 
+      addBundle({
+        kind: "single-call",
+        title: `Simulation · ${fnName || "unknown"}`,
+        networkId: network.id,
+        workspaceId: activeWorkspaceId,
+        contractId,
+        payload: {
+          mode: "simulate",
+          fnName,
+          args,
+          simulation: normalized,
+        },
+      });
+
       if (normalized.ok) {
         setResult("Simulation succeeded.");
         toast.success(`Simulation Success!`);
@@ -341,6 +359,22 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
         ),
       );
 
+      addBundle({
+        kind: "single-call",
+        title: `Transaction · ${fnName || "unknown"}`,
+        networkId: network.id,
+        workspaceId: activeWorkspaceId,
+        contractId,
+        txHash: sendRes.hash,
+        payload: {
+          mode: "submit",
+          fnName,
+          args,
+          sendStatus: sendRes.status,
+          simulation: normalizeSimulationResult(sim),
+        },
+      });
+
       if (sendRes.status !== "PENDING") {
         throw new Error(`Submission failed: ${sendRes.status}`);
       }
@@ -396,6 +430,40 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
     const newArgs = call.args.map((a) => ({ ...a, id: crypto.randomUUID() }));
     setArgs(newArgs);
     toast.info(`Loaded: ${call.name}`);
+  };
+
+  const handleSavePreset = () => {
+    if (!fnName) return;
+    const network = getActiveNetworkConfig();
+    savePreset({
+      name: saveName.trim() || `${fnName} preset`,
+      contractId,
+      fnName,
+      args,
+      network: network.id,
+      source: "custom",
+    });
+    toast.success("Operation preset saved");
+  };
+
+  const handleExportBundle = () => {
+    const network = getActiveNetworkConfig();
+    const bundle = addBundle({
+      kind: "single-call",
+      title: `Export · ${fnName || "contract-call"}`,
+      networkId: network.id,
+      workspaceId: activeWorkspaceId,
+      contractId,
+      payload: {
+        mode: "manual-export",
+        fnName,
+        args,
+        result,
+        simulation,
+      },
+    });
+    exportResultBundle(bundle);
+    toast.success("Result bundle exported");
   };
 
   return (
@@ -467,16 +535,27 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
 
         <Dialog open={isSaveOpen} onOpenChange={setIsSaveOpen}>
           <ActionGuard action="submit">
-            <DialogTrigger asChild>
+            <div className="flex gap-2">
+              <DialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="icon"
+                  title="Save Interaction"
+                  disabled={!fnName}
+                >
+                  <Save className="h-4 w-4" />
+                </Button>
+              </DialogTrigger>
               <Button
                 variant="outline"
-                size="icon"
-                title="Save Interaction"
+                size="sm"
+                title="Save reusable operation preset"
                 disabled={!fnName}
+                onClick={handleSavePreset}
               >
-                <Save className="h-4 w-4" />
+                Save Preset
               </Button>
-            </DialogTrigger>
+            </div>
           </ActionGuard>
           <DialogContent>
             <DialogHeader>
@@ -777,14 +856,24 @@ export function ContractCallForm({ contractId }: ContractCallFormProps) {
         </div>
         {result && (
           <ActionGuard action="submit">
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={handlePin}
-              title="Pin this result for comparison"
-            >
-              <Bookmark className="mr-1 h-3 w-3" /> Pin Result
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handlePin}
+                title="Pin this result for comparison"
+              >
+                <Bookmark className="mr-1 h-3 w-3" /> Pin Result
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleExportBundle}
+                title="Export structured result bundle"
+              >
+                <Download className="mr-1 h-3 w-3" /> Export Bundle
+              </Button>
+            </div>
           </ActionGuard>
         )}
 

--- a/apps/web/components/data-management.tsx
+++ b/apps/web/components/data-management.tsx
@@ -55,6 +55,9 @@ import {
 import { useNetworkStore } from "@/store/useNetworkStore";
 import { STORE_SCHEMA_VERSION } from "@/store/schema-version";
 import type { ShareSummary } from "@devconsole/api-contracts";
+import { useResultBundlesStore } from "@/store/useResultBundlesStore";
+import { exportAllResultBundles, exportResultBundle } from "@/lib/result-bundles";
+import { useWasmStore } from "@/store/useWasmStore";
 
 // The keys defined in your Zustand 'persist' middleware options
 const STORAGE_KEYS = {
@@ -321,7 +324,10 @@ export function DataManagement() {
   const { getActiveWorkspace, cloudId } = useWorkspaceStore();
   const { contracts } = useContractStore();
   const { savedCalls } = useSavedCallsStore();
+  const { bundles, removeBundle, clearBundles } = useResultBundlesStore();
+  const { wasms } = useWasmStore();
   const { getActiveNetworkConfig } = useNetworkStore();
+  const deployOutcomes = wasms.filter((entry) => Boolean(entry.deployedContractId));
 
   const handleExport = () => {
     try {
@@ -653,6 +659,132 @@ export function DataManagement() {
               )}
               Generate Bundle
             </Button>
+          </div>
+
+          {/* FE-055: Result bundle export */}
+          <div className="rounded-md border p-3 space-y-2">
+            <div className="flex items-start gap-2">
+              <Package className="mt-0.5 h-4 w-4 shrink-0 text-muted-foreground" />
+              <div className="flex-1">
+                <p className="text-sm font-medium">Result Bundles</p>
+                <p className="text-xs text-muted-foreground">
+                  Export simulation and transaction outcomes from single-call,
+                  batch, and deployment workflows.
+                </p>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={bundles.length === 0}
+                onClick={() => {
+                  exportAllResultBundles(bundles);
+                  toast.success("All result bundles exported");
+                }}
+              >
+                <Download className="mr-2 h-3 w-3" />
+                Export All Bundles ({bundles.length})
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={bundles.length === 0}
+                onClick={() => {
+                  clearBundles();
+                  toast.success("Result bundles cleared");
+                }}
+              >
+                <Trash2 className="mr-2 h-3 w-3" />
+                Clear Bundles
+              </Button>
+            </div>
+
+            {bundles.length > 0 && (
+              <div className="space-y-2">
+                {bundles.slice(0, 8).map((bundle) => (
+                  <div
+                    key={bundle.id}
+                    className="flex items-center justify-between rounded-md border px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{bundle.title}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {bundle.kind} · {bundle.networkId} ·{" "}
+                        {new Date(bundle.createdAt).toLocaleString()}
+                      </p>
+                    </div>
+                    <div className="flex items-center gap-1">
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => exportResultBundle(bundle)}
+                        aria-label="Export result bundle"
+                      >
+                        <Download className="h-3.5 w-3.5" />
+                      </Button>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        onClick={() => removeBundle(bundle.id)}
+                        aria-label="Delete result bundle"
+                      >
+                        <Trash2 className="h-3.5 w-3.5 text-red-500" />
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+
+            {deployOutcomes.length > 0 && (
+              <div className="space-y-2 pt-1">
+                <p className="text-xs font-medium text-muted-foreground">
+                  Deployment Outcomes
+                </p>
+                {deployOutcomes.slice(0, 5).map((entry) => (
+                  <div
+                    key={`${entry.hash}-${entry.deployedContractId}`}
+                    className="flex items-center justify-between rounded-md border px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{entry.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {entry.network} · {entry.deployedContractId}
+                      </p>
+                    </div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        const bundle = {
+                          id: crypto.randomUUID(),
+                          kind: "deploy" as const,
+                          title: `Deploy outcome · ${entry.name}`,
+                          createdAt: entry.deployedAt ?? Date.now(),
+                          networkId: entry.network,
+                          contractId: entry.deployedContractId,
+                          payload: {
+                            wasmHash: entry.hash,
+                            version: entry.version,
+                            installedAt: entry.installedAt,
+                            deployedAt: entry.deployedAt,
+                            workspaceId: entry.workspaceId,
+                            provenance: entry.provenance,
+                          },
+                        };
+                        exportResultBundle(bundle);
+                        toast.success("Deploy outcome bundle exported");
+                      }}
+                    >
+                      <Download className="mr-2 h-3 w-3" />
+                      Export
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
           </div>
 
           {/* FE-037: Recovery Tooling */}

--- a/apps/web/components/fund-account-button.tsx
+++ b/apps/web/components/fund-account-button.tsx
@@ -3,36 +3,33 @@
 import { useState } from "react";
 import { useWallet } from "@/store/useWallet";
 import { useNetworkStore } from "@/store/useNetworkStore";
-import { fundAccount } from "@/lib/friendbot";
+import { canFundWithProvider, fundWithProvider } from "@/lib/funding";
 import { Button } from "@devconsole/ui";
 import { Loader2, Coins } from "lucide-react";
 import { toast } from "sonner";
 
 export function FundAccountButton() {
   const { address, isConnected } = useWallet();
-  const { currentNetwork } = useNetworkStore();
+  const { getFundingProvider } = useNetworkStore();
   const [isLoading, setIsLoading] = useState(false);
 
-  // Friendbot is only available on Testnet (and sometimes Futurenet)
-  const isTestnet =
-    currentNetwork === "testnet" || currentNetwork === "futurenet";
+  const provider = getFundingProvider();
+  const canFund = canFundWithProvider(provider);
 
-  if (!isConnected || !address || !isTestnet) {
+  if (!isConnected || !address || !canFund) {
     return null;
   }
 
   const handleFund = async () => {
     setIsLoading(true);
-    const toastId = toast.loading("Requesting funds from Friendbot...");
+    const toastId = toast.loading("Requesting account funding...");
 
     try {
-      await fundAccount(address);
-      toast.success("Account funded! You received 10,000 XLM.", {
+      const result = await fundWithProvider(address, provider);
+      toast.success(result.message, {
         id: toastId,
       });
 
-      // Optional: Refresh the page to update balances immediately
-      // A better way is to trigger a refetch in your Dashboard component via a shared signal
       setTimeout(() => window.location.reload(), 2000);
     } catch (error: any) {
       toast.error(`Funding failed: ${error.message}`, { id: toastId });
@@ -53,7 +50,7 @@ export function FundAccountButton() {
       ) : (
         <Coins className="h-4 w-4" />
       )}
-      {isLoading ? "Funding..." : "Get Testnet XLM"}
+      {isLoading ? "Funding..." : provider.label ?? "Fund Account"}
     </Button>
   );
 }

--- a/apps/web/components/token-dashboard.tsx
+++ b/apps/web/components/token-dashboard.tsx
@@ -11,6 +11,8 @@ import {
   TimeoutInfinite,
 } from "@stellar/stellar-sdk";
 import { useNetworkStore } from "@/store/useNetworkStore";
+import { useSavedCallsStore } from "@/store/useSavedCallsStore";
+import { useWorkspaceStore } from "@/store/useWorkspaceStore";
 import {
   Card,
   CardContent,
@@ -44,6 +46,13 @@ interface TokenMetadata {
 export function TokenDashboard({ contractId }: TokenDashboardProps) {
   const { getActiveNetworkConfig } = useNetworkStore();
   const { address } = useWallet();
+  const { activeWorkspaceId } = useWorkspaceStore();
+  const {
+    savePreset,
+    getPresetsForContract,
+    applyPresetToCart,
+    repairPresetNetwork,
+  } = useSavedCallsStore();
 
   const [metadata, setMetadata] = useState<TokenMetadata | null>(null);
   const [loading, setLoading] = useState(true);
@@ -53,6 +62,9 @@ export function TokenDashboard({ contractId }: TokenDashboardProps) {
   const [checkAddress, setCheckAddress] = useState("");
   const [balance, setBalance] = useState<string | null>(null);
   const [checking, setChecking] = useState(false);
+
+  const networkId = getActiveNetworkConfig().id;
+  const presets = getPresetsForContract(contractId);
 
   const callView = async (method: string, args: any[] = []) => {
     const network = getActiveNetworkConfig();
@@ -151,6 +163,22 @@ export function TokenDashboard({ contractId }: TokenDashboardProps) {
 
   if (!isToken || !metadata) return null;
 
+  const createTokenPreset = (
+    name: string,
+    fnName: string,
+    args: Array<{ name: string; type: "address" | "i128" | "symbol" | "string"; value: string }>,
+  ) => {
+    savePreset({
+      name,
+      contractId,
+      fnName,
+      args: args.map((arg) => ({ id: crypto.randomUUID(), ...arg })),
+      network: networkId,
+      source: "token",
+    });
+    toast.success("Preset saved");
+  };
+
   return (
     <Card className="mb-6 border-blue-200 bg-blue-50/30 dark:border-blue-900 dark:bg-blue-900/10">
       <CardHeader className="pb-3">
@@ -220,21 +248,81 @@ export function TokenDashboard({ contractId }: TokenDashboardProps) {
               <Button
                 variant="outline"
                 size="sm"
-                className="w-full shrink-0 cursor-not-allowed justify-start gap-2 opacity-70"
+                className="w-full justify-start gap-2"
+                onClick={() =>
+                  createTokenPreset("Token transfer", "transfer", [
+                    { name: "from", type: "address", value: address ?? "" },
+                    { name: "to", type: "address", value: "" },
+                    { name: "amount", type: "i128", value: "0" },
+                  ])
+                }
               >
-                <ArrowRightLeft className="h-4 w-4" /> Transfer
+                <ArrowRightLeft className="h-4 w-4" /> Save Transfer Preset
               </Button>
               <Button
                 variant="outline"
                 size="sm"
-                className="w-full shrink-0 cursor-not-allowed justify-start gap-2 break-all opacity-70"
+                className="w-full justify-start gap-2"
+                onClick={() =>
+                  createTokenPreset("Token mint", "mint", [
+                    { name: "to", type: "address", value: address ?? "" },
+                    { name: "amount", type: "i128", value: "0" },
+                  ])
+                }
               >
-                <Coins className="h-4 w-4" /> Mint
+                <Coins className="h-4 w-4" /> Save Mint Preset
               </Button>
             </div>
-            <p className="pt-1 text-[10px] text-muted-foreground">
-              * Use the "Interact" form below to execute these transfers.
-            </p>
+
+            {presets.length > 0 && (
+              <div className="space-y-2 pt-1">
+                {presets.slice(0, 4).map((preset) => {
+                  const isStale = preset.network !== networkId;
+                  return (
+                    <div
+                      key={preset.id}
+                      className="flex items-center justify-between rounded-md border bg-background px-2 py-1"
+                    >
+                      <div className="min-w-0">
+                        <p className="truncate text-xs font-medium">{preset.name}</p>
+                        <p className="text-[10px] text-muted-foreground">
+                          {preset.fnName} · {preset.network}
+                          {isStale ? " · stale" : ""}
+                        </p>
+                      </div>
+                      <div className="flex gap-1">
+                        {isStale && (
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            onClick={() => {
+                              repairPresetNetwork(preset.id, networkId);
+                              toast.success("Preset repaired for current network");
+                            }}
+                          >
+                            Repair
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => {
+                            const call = applyPresetToCart(preset.id, {
+                              workspaceId: activeWorkspaceId,
+                            });
+                            if (call) {
+                              toast.success("Preset added to saved calls and batch cart");
+                            }
+                          }}
+                        >
+                          Add
+                        </Button>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            )}
           </div>
         </div>
       </CardContent>

--- a/apps/web/lib/funding.ts
+++ b/apps/web/lib/funding.ts
@@ -1,0 +1,79 @@
+import type { FundingProviderConfig } from "@/store/useNetworkStore";
+
+export interface FundingResult {
+  provider: FundingProviderConfig["type"];
+  success: boolean;
+  message: string;
+  transactionHash?: string;
+  raw?: unknown;
+}
+
+async function runFriendbot(address: string, endpoint: string): Promise<FundingResult> {
+  const response = await fetch(`${endpoint}/?addr=${encodeURIComponent(address)}`);
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const detail =
+      (data && typeof data === "object" && "detail" in data && String((data as any).detail)) ||
+      "Funding failed";
+    throw new Error(detail);
+  }
+
+  return {
+    provider: "friendbot",
+    success: true,
+    message: "Account funded successfully",
+    transactionHash:
+      data && typeof data === "object" && "hash" in data ? String((data as any).hash) : undefined,
+    raw: data,
+  };
+}
+
+async function runCustomHttp(address: string, endpoint: string): Promise<FundingResult> {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ address }),
+  });
+
+  const data = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const detail =
+      (data && typeof data === "object" && "message" in data && String((data as any).message)) ||
+      "Funding failed";
+    throw new Error(detail);
+  }
+
+  return {
+    provider: "custom-http",
+    success: true,
+    message:
+      (data && typeof data === "object" && "message" in data && String((data as any).message)) ||
+      "Funding requested successfully",
+    raw: data,
+  };
+}
+
+export function canFundWithProvider(provider: FundingProviderConfig): boolean {
+  return provider.type !== "none";
+}
+
+export async function fundWithProvider(
+  address: string,
+  provider: FundingProviderConfig,
+): Promise<FundingResult> {
+  if (provider.type === "none") {
+    throw new Error("Funding is not supported on this network");
+  }
+
+  if (provider.type === "friendbot") {
+    const endpoint = provider.endpoint ?? "https://friendbot.stellar.org";
+    return runFriendbot(address, endpoint);
+  }
+
+  const endpoint = provider.endpoint;
+  if (!endpoint) {
+    throw new Error("Funding provider is missing endpoint configuration");
+  }
+  return runCustomHttp(address, endpoint);
+}

--- a/apps/web/lib/result-bundles.ts
+++ b/apps/web/lib/result-bundles.ts
@@ -1,0 +1,33 @@
+import type { ResultBundle } from "@/store/useResultBundlesStore";
+
+export function downloadJsonFile(filename: string, payload: unknown): void {
+  const blob = new Blob([JSON.stringify(payload, null, 2)], {
+    type: "application/json",
+  });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+export function exportResultBundle(bundle: ResultBundle): void {
+  const stamp = new Date(bundle.createdAt).toISOString().slice(0, 19).replace(/:/g, "-");
+  downloadJsonFile(`result-bundle-${bundle.kind}-${stamp}.json`, {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    bundle,
+  });
+}
+
+export function exportAllResultBundles(bundles: ResultBundle[]): void {
+  downloadJsonFile(`result-bundles-${new Date().toISOString().slice(0, 10)}.json`, {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    count: bundles.length,
+    bundles,
+  });
+}

--- a/apps/web/store/useNetworkStore.ts
+++ b/apps/web/store/useNetworkStore.ts
@@ -16,6 +16,13 @@ export interface NetworkConfig {
   networkPassphrase: string;
   horizonUrl?: string;
   isCustom?: boolean;
+  funding?: FundingProviderConfig;
+}
+
+export interface FundingProviderConfig {
+  type: "none" | "friendbot" | "custom-http";
+  label?: string;
+  endpoint?: string;
 }
 
 // Default/System Networks (Read-only)
@@ -33,6 +40,11 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     rpcUrl: "https://soroban-testnet.stellar.org",
     networkPassphrase: "Test SDF Network ; September 2015",
     horizonUrl: "https://horizon-testnet.stellar.org",
+    funding: {
+      type: "friendbot",
+      label: "Get Testnet XLM",
+      endpoint: "https://friendbot.stellar.org",
+    },
   },
   futurenet: {
     id: "futurenet",
@@ -40,6 +52,9 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     rpcUrl: "https://rpc-futurenet.stellar.org",
     networkPassphrase: "Test SDF Future Network ; October 2022",
     horizonUrl: "https://horizon-futurenet.stellar.org",
+    funding: {
+      type: "none",
+    },
   },
   local: {
     id: "local",
@@ -47,6 +62,9 @@ export const DEFAULT_NETWORKS: Record<string, NetworkConfig> = {
     rpcUrl: "http://localhost:8000/soroban/rpc",
     networkPassphrase: "Standalone Network ; February 2017",
     horizonUrl: "http://localhost:8000",
+    funding: {
+      type: "none",
+    },
   },
 };
 
@@ -64,6 +82,7 @@ interface NetworkState {
   getActiveNetworkConfig: () => NetworkConfig;
   getAllNetworks: () => NetworkConfig[];
   getHorizonUrl: () => string;
+  getFundingProvider: () => FundingProviderConfig;
   // FE-042: check if a previously-recorded network still matches current
   isNetworkMismatch: (recordedNetworkId: string | null) => boolean;
 }
@@ -111,6 +130,11 @@ export const useNetworkStore = create<NetworkState>()(
       getHorizonUrl: () => {
         const network = get().getActiveNetworkConfig();
         return network.horizonUrl ?? DEFAULT_NETWORKS["testnet"].horizonUrl!;
+      },
+
+      getFundingProvider: () => {
+        const network = get().getActiveNetworkConfig();
+        return network.funding ?? { type: "none" };
       },
 
       // FE-042: returns true when the active network differs from a recorded one

--- a/apps/web/store/useResultBundlesStore.ts
+++ b/apps/web/store/useResultBundlesStore.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+export type ResultBundleKind = "single-call" | "batch" | "deploy";
+
+export interface ResultBundle {
+  id: string;
+  kind: ResultBundleKind;
+  title: string;
+  createdAt: number;
+  networkId: string;
+  workspaceId?: string;
+  contractId?: string;
+  txHash?: string;
+  payload: unknown;
+}
+
+interface ResultBundlesState {
+  bundles: ResultBundle[];
+  addBundle: (bundle: Omit<ResultBundle, "id" | "createdAt">) => ResultBundle;
+  removeBundle: (id: string) => void;
+  clearBundles: () => void;
+  getRecentBundles: (limit?: number) => ResultBundle[];
+}
+
+export const useResultBundlesStore = create<ResultBundlesState>()(
+  persist(
+    (set, get) => ({
+      bundles: [],
+
+      addBundle: (bundle) => {
+        const entry: ResultBundle = {
+          ...bundle,
+          id: crypto.randomUUID(),
+          createdAt: Date.now(),
+        };
+        set((state) => ({ bundles: [entry, ...state.bundles].slice(0, 200) }));
+        return entry;
+      },
+
+      removeBundle: (id) =>
+        set((state) => ({ bundles: state.bundles.filter((bundle) => bundle.id !== id) })),
+
+      clearBundles: () => set({ bundles: [] }),
+
+      getRecentBundles: (limit = 20) => get().bundles.slice(0, limit),
+    }),
+    { name: "soroban-result-bundles" },
+  ),
+);

--- a/apps/web/store/useSavedCallsStore.ts
+++ b/apps/web/store/useSavedCallsStore.ts
@@ -17,9 +17,22 @@ export interface CartItem extends SavedCall {
   cartItemId: string;
 }
 
+export interface OperationPreset {
+  id: string;
+  name: string;
+  contractId: string;
+  fnName: string;
+  args: ContractArg[];
+  network: string;
+  source: "token" | "admin" | "explorer" | "custom";
+  createdAt: number;
+  lastUsedAt?: number;
+}
+
 interface SavedCallsState {
   savedCalls: SavedCall[];
   cartItems: CartItem[];
+  presets: OperationPreset[];
   saveCall: (call: Omit<SavedCall, "id" | "createdAt">) => SavedCall;
   removeCall: (id: string) => void;
   getCallsForContract: (contractId: string) => SavedCall[];
@@ -30,6 +43,14 @@ interface SavedCallsState {
   getCallsForWorkspace: (workspaceId: string) => SavedCall[];
   assignCallToWorkspace: (callId: string, workspaceId: string) => void;
   unassignCallFromWorkspace: (callId: string) => void;
+  /** FE-056: persist reusable operation presets */
+  savePreset: (preset: Omit<OperationPreset, "id" | "createdAt" | "lastUsedAt">) => OperationPreset;
+  removePreset: (presetId: string) => void;
+  getPresetsForContract: (contractId: string) => OperationPreset[];
+  /** FE-056: apply a preset by creating a saved call and adding it to cart */
+  applyPresetToCart: (presetId: string, options?: { workspaceId?: string }) => SavedCall | null;
+  /** FE-056: recover stale preset by switching network context */
+  repairPresetNetwork: (presetId: string, network: string) => void;
 }
 
 export const useSavedCallsStore = create<SavedCallsState>()(
@@ -37,6 +58,7 @@ export const useSavedCallsStore = create<SavedCallsState>()(
     (set, get) => ({
       savedCalls: [],
       cartItems: [],
+      presets: [],
 
       saveCall: (call) => {
         const savedCall: SavedCall = {
@@ -96,6 +118,57 @@ export const useSavedCallsStore = create<SavedCallsState>()(
         set((state) => ({
           savedCalls: state.savedCalls.map((c) =>
             c.id === callId ? { ...c, workspaceId: undefined } : c,
+          ),
+        })),
+
+      savePreset: (preset) => {
+        const next: OperationPreset = {
+          ...preset,
+          id: crypto.randomUUID(),
+          createdAt: Date.now(),
+        };
+        set((state) => ({ presets: [next, ...state.presets] }));
+        return next;
+      },
+
+      removePreset: (presetId) =>
+        set((state) => ({
+          presets: state.presets.filter((preset) => preset.id !== presetId),
+        })),
+
+      getPresetsForContract: (contractId) =>
+        get().presets.filter((preset) => preset.contractId === contractId),
+
+      applyPresetToCart: (presetId, options) => {
+        const preset = get().presets.find((entry) => entry.id === presetId);
+        if (!preset) return null;
+
+        const savedCall: SavedCall = {
+          id: crypto.randomUUID(),
+          name: preset.name,
+          contractId: preset.contractId,
+          fnName: preset.fnName,
+          args: preset.args,
+          network: preset.network,
+          createdAt: Date.now(),
+          workspaceId: options?.workspaceId,
+        };
+
+        set((state) => ({
+          savedCalls: [savedCall, ...state.savedCalls],
+          cartItems: [...state.cartItems, { ...savedCall, cartItemId: crypto.randomUUID() }],
+          presets: state.presets.map((entry) =>
+            entry.id === presetId ? { ...entry, lastUsedAt: Date.now() } : entry,
+          ),
+        }));
+
+        return savedCall;
+      },
+
+      repairPresetNetwork: (presetId, network) =>
+        set((state) => ({
+          presets: state.presets.map((preset) =>
+            preset.id === presetId ? { ...preset, network } : preset,
           ),
         })),
     }),

--- a/apps/web/store/useWorkspaceStore.ts
+++ b/apps/web/store/useWorkspaceStore.ts
@@ -41,6 +41,22 @@ export interface ConflictResult {
 /** FE-029: Strategy for resolving a detected conflict. */
 export type MergeStrategy = "keep-local" | "keep-remote" | "merge-additive";
 
+export type ContractBookmarkSource =
+  | "contracts-page"
+  | "command-palette"
+  | "fixture"
+  | "manual";
+
+export interface ContractBookmark {
+  id: string;
+  workspaceId: string;
+  contractId: string;
+  networkId: string;
+  source: ContractBookmarkSource;
+  favorite: boolean;
+  createdAt: number;
+}
+
 interface WorkspaceState {
   workspaces: WorkspaceSnapshot[];
   activeWorkspaceId: string;
@@ -52,6 +68,8 @@ interface WorkspaceState {
   checkpoints: Record<string, WorkspaceCheckpoint[]>;
   /** FE-029: Pending conflict data awaiting user resolution */
   pendingConflict: (ConflictResult & { remoteSnapshot: WorkspaceSnapshot }) | null;
+  /** FE-054: Contract bookmarks keyed by workspace ID */
+  contractBookmarks: Record<string, ContractBookmark[]>;
 
   createWorkspace: (name: string, selectedNetwork?: string) => void;
   /** FE-032: Create a workspace pre-populated from a template */
@@ -88,6 +106,21 @@ interface WorkspaceState {
   resolveConflict: (strategy: MergeStrategy) => void;
   /** FE-029: Dismiss the pending conflict without resolving */
   dismissConflict: () => void;
+  /** FE-054: Save contract bookmark with network/source context */
+  bookmarkContract: (
+    workspaceId: string,
+    contractId: string,
+    networkId: string,
+    source: ContractBookmarkSource,
+  ) => ContractBookmark;
+  /** FE-054: Remove a contract bookmark */
+  removeContractBookmark: (workspaceId: string, bookmarkId: string) => void;
+  /** FE-054: Toggle bookmark as favorite */
+  toggleBookmarkFavorite: (workspaceId: string, bookmarkId: string) => void;
+  /** FE-054: Repair bookmark network context */
+  repairBookmarkNetwork: (workspaceId: string, bookmarkId: string, networkId: string) => void;
+  /** FE-054: Retrieve workspace bookmarks (favorites first) */
+  getContractBookmarks: (workspaceId: string) => ContractBookmark[];
 }
 
 function createWorkspaceSnapshot(
@@ -166,6 +199,7 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       syncError: null,
       checkpoints: {},
       pendingConflict: null,
+      contractBookmarks: {},
 
       createWorkspace: (name, selectedNetwork = useNetworkStore.getState().currentNetwork) =>
         set((state) => ({
@@ -383,6 +417,91 @@ export const useWorkspaceStore = create<WorkspaceState>()(
       },
 
       dismissConflict: () => set({ pendingConflict: null, syncState: "idle" }),
+
+      bookmarkContract: (workspaceId, contractId, networkId, source) => {
+        const bookmark: ContractBookmark = {
+          id: crypto.randomUUID(),
+          workspaceId,
+          contractId,
+          networkId,
+          source,
+          favorite: false,
+          createdAt: Date.now(),
+        };
+
+        set((state) => {
+          const existing = state.contractBookmarks[workspaceId] ?? [];
+          const duplicate = existing.find(
+            (entry) =>
+              entry.contractId === contractId && entry.networkId === networkId,
+          );
+          if (duplicate) {
+            return {
+              contractBookmarks: {
+                ...state.contractBookmarks,
+                [workspaceId]: existing.map((entry) =>
+                  entry.id === duplicate.id
+                    ? { ...entry, source, createdAt: Date.now() }
+                    : entry,
+                ),
+              },
+            };
+          }
+
+          return {
+            contractBookmarks: {
+              ...state.contractBookmarks,
+              [workspaceId]: [bookmark, ...existing],
+            },
+          };
+        });
+
+        return bookmark;
+      },
+
+      removeContractBookmark: (workspaceId, bookmarkId) =>
+        set((state) => ({
+          contractBookmarks: {
+            ...state.contractBookmarks,
+            [workspaceId]: (state.contractBookmarks[workspaceId] ?? []).filter(
+              (entry) => entry.id !== bookmarkId,
+            ),
+          },
+        })),
+
+      toggleBookmarkFavorite: (workspaceId, bookmarkId) =>
+        set((state) => ({
+          contractBookmarks: {
+            ...state.contractBookmarks,
+            [workspaceId]: (state.contractBookmarks[workspaceId] ?? []).map(
+              (entry) =>
+                entry.id === bookmarkId
+                  ? { ...entry, favorite: !entry.favorite }
+                  : entry,
+            ),
+          },
+        })),
+
+      repairBookmarkNetwork: (workspaceId, bookmarkId, networkId) =>
+        set((state) => ({
+          contractBookmarks: {
+            ...state.contractBookmarks,
+            [workspaceId]: (state.contractBookmarks[workspaceId] ?? []).map(
+              (entry) =>
+                entry.id === bookmarkId
+                  ? { ...entry, networkId }
+                  : entry,
+            ),
+          },
+        })),
+
+      getContractBookmarks: (workspaceId) => {
+        const entries = get().contractBookmarks[workspaceId] ?? [];
+        return [...entries].sort((a, b) => {
+          if (a.favorite === b.favorite) return b.createdAt - a.createdAt;
+          return a.favorite ? -1 : 1;
+        });
+      },
 
       // ── Cloud sync ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
This PR implements the four assigned frontend issues for A6dulmalik:
- Closes #201
- Closes #202
- Closes #203
- Closes #204

### What was implemented
1. FE-053: Pluggable funding providers
- Added network-declared funding provider config in the network store
- Added provider execution + normalized funding result utilities
- Updated account funding controls to hide on unsupported networks

2. FE-054: Contract bookmarks, favorites, and quick actions
- Added workspace-scoped contract bookmarks with network/source context
- Added favorite toggling and bookmark repair helpers
- Integrated bookmark actions in contracts page and command palette
- Surfaced stale bookmarks and repair action in explorer UI

3. FE-055: Exportable transaction/result bundles
- Added persisted result bundle store
- Added JSON export utilities for single/all bundles
- Added single-call + batch bundle capture and export actions
- Added result bundle management section in Data Management
- Added deploy outcome bundle exports from tracked WASM outcomes

4. FE-056: Operation presets for common flows
- Added reusable operation preset model in saved calls store
- Added preset apply-to-cart flow that goes through saved calls + batch cart
- Added preset creation in contract call form
- Added token dashboard quick preset creation, stale detection, and repair

## Validation
- Ran npm run typecheck
- Existing unrelated type errors remain in:
  - apps/web/app/deploy/wasm/page.tsx (isSandboxMode not defined)
  - apps/web/components/action-guard.tsx (React clone typing issues)
- No additional type errors were introduced by this PR.
