### PR TITLE
BE/DevOps: workspace warnings, conflict payloads, deploy decoder, round-trip fixtures

### DIFF
--- a/apps/api/src/modules/rpc/deploy-result-decoder.ts
+++ b/apps/api/src/modules/rpc/deploy-result-decoder.ts
@@ -1,0 +1,54 @@
+/**
+ * BE-021: Backend helpers for deploy result and contract metadata decoding.
+ * Normalizes contract creation metadata so browser consumers skip raw XDR handling.
+ */
+
+export interface DeployResultMeta {
+  contractId: string | null;
+  wasmHash: string | null;
+  ledger: number | null;
+  txHash: string | null;
+  error: string | null;
+}
+
+export interface RawDeployResult {
+  status?: string;
+  hash?: string;
+  ledger?: number;
+  resultMetaXdr?: string;
+  contractId?: string;
+  wasmHash?: string;
+  error?: string;
+}
+
+export function decodeDeployResult(raw: RawDeployResult): DeployResultMeta {
+  if (!raw || raw.status === "FAILED") {
+    return {
+      contractId: null,
+      wasmHash: null,
+      ledger: raw?.ledger ?? null,
+      txHash: raw?.hash ?? null,
+      error: raw?.error ?? "deploy failed with no additional context",
+    };
+  }
+
+  return {
+    contractId: raw.contractId ?? null,
+    wasmHash: raw.wasmHash ?? null,
+    ledger: raw.ledger ?? null,
+    txHash: raw.hash ?? null,
+    error: null,
+  };
+}
+
+export function isSuccessfulDeploy(meta: DeployResultMeta): boolean {
+  return meta.contractId !== null && meta.error === null;
+}
+
+export function safeDecodeDeployResult(raw: unknown): DeployResultMeta {
+  try {
+    return decodeDeployResult(raw as RawDeployResult);
+  } catch {
+    return { contractId: null, wasmHash: null, ledger: null, txHash: null, error: "decode failed" };
+  }
+}

--- a/apps/api/src/modules/workspaces/revision-conflict.ts
+++ b/apps/api/src/modules/workspaces/revision-conflict.ts
@@ -1,0 +1,55 @@
+/**
+ * BE-020: Structured revision conflict payloads for workspace update failures.
+ * Gives clients enough metadata to drive merge/retry without parsing error text.
+ */
+
+export interface RevisionConflictPayload {
+  type: "REVISION_CONFLICT";
+  workspaceId: string;
+  expectedRevision: number;
+  actualRevision: number;
+  hint: string;
+}
+
+export interface RevisionConflictResponse {
+  ok: false;
+  conflict: RevisionConflictPayload;
+}
+
+export function buildConflictPayload(
+  workspaceId: string,
+  expectedRevision: number,
+  actualRevision: number
+): RevisionConflictPayload {
+  return {
+    type: "REVISION_CONFLICT",
+    workspaceId,
+    expectedRevision,
+    actualRevision,
+    hint: `Remote is at revision ${actualRevision}; re-fetch and reapply your changes before retrying.`,
+  };
+}
+
+export function buildConflictResponse(
+  workspaceId: string,
+  expectedRevision: number,
+  actualRevision: number
+): RevisionConflictResponse {
+  return {
+    ok: false,
+    conflict: buildConflictPayload(workspaceId, expectedRevision, actualRevision),
+  };
+}
+
+export function isRevisionConflict(err: unknown): err is RevisionConflictResponse {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    (err as RevisionConflictResponse).ok === false &&
+    (err as RevisionConflictResponse).conflict?.type === "REVISION_CONFLICT"
+  );
+}
+
+export function isStaleRevision(expected: number, actual: number): boolean {
+  return actual > expected;
+}

--- a/apps/api/src/modules/workspaces/workspace-validation-warnings.ts
+++ b/apps/api/src/modules/workspaces/workspace-validation-warnings.ts
@@ -1,0 +1,68 @@
+/**
+ * BE-019: Structured validation warnings for workspace import/export API responses.
+ * Exposes repair and partial-trust signals so clients don't rely on string parsing.
+ */
+
+import { ApiWarning, repairWarning, fallbackWarning } from "@soroban-dev-console/api-contracts";
+
+export interface WorkspaceValidationResult {
+  ok: boolean;
+  warnings: ApiWarning[];
+  unrecoverable: string[];
+}
+
+export function validateImportPayload(raw: unknown): WorkspaceValidationResult {
+  const warnings: ApiWarning[] = [];
+  const unrecoverable: string[] = [];
+
+  if (typeof raw !== "object" || raw === null) {
+    unrecoverable.push("payload must be a non-null object");
+    return { ok: false, warnings, unrecoverable };
+  }
+
+  const payload = raw as Record<string, unknown>;
+
+  if (!payload.name || typeof payload.name !== "string") {
+    unrecoverable.push("missing required field: name");
+  }
+
+  if (!payload.selectedNetwork) {
+    warnings.push(repairWarning("MISSING_NETWORK", "selectedNetwork absent; defaulted to testnet", { field: "selectedNetwork" }));
+  }
+
+  if (!Array.isArray(payload.savedContracts)) {
+    warnings.push(repairWarning("MISSING_CONTRACTS", "savedContracts absent; defaulted to empty array", { field: "savedContracts" }));
+  }
+
+  if (!Array.isArray(payload.savedInteractions)) {
+    warnings.push(repairWarning("MISSING_INTERACTIONS", "savedInteractions absent; defaulted to empty array", { field: "savedInteractions" }));
+  }
+
+  if (payload.schemaVersion !== undefined && typeof payload.schemaVersion === "number" && payload.schemaVersion < 2) {
+    warnings.push(fallbackWarning("LEGACY_SCHEMA", "payload uses a legacy schema version; some fields may be missing", { schemaVersion: payload.schemaVersion }));
+  }
+
+  return { ok: unrecoverable.length === 0, warnings, unrecoverable };
+}
+
+export function validateExportPayload(raw: unknown): WorkspaceValidationResult {
+  const warnings: ApiWarning[] = [];
+  const unrecoverable: string[] = [];
+
+  if (typeof raw !== "object" || raw === null) {
+    unrecoverable.push("export source must be a non-null object");
+    return { ok: false, warnings, unrecoverable };
+  }
+
+  const payload = raw as Record<string, unknown>;
+
+  if (!payload.id || typeof payload.id !== "string") {
+    unrecoverable.push("missing required field: id");
+  }
+
+  if (!Array.isArray(payload.artifacts) || payload.artifacts.length === 0) {
+    warnings.push(fallbackWarning("NO_ARTIFACTS", "export contains no artifacts; downstream consumers may be incomplete", { field: "artifacts" }));
+  }
+
+  return { ok: unrecoverable.length === 0, warnings, unrecoverable };
+}

--- a/apps/web/test/workspace-round-trip-fixtures.ts
+++ b/apps/web/test/workspace-round-trip-fixtures.ts
@@ -1,0 +1,73 @@
+/**
+ * DEVOPS-023: Regression fixtures for workspace export/import round-trip auditing.
+ * Curated payloads covering healthy, repaired, legacy, and dependency-heavy workspaces.
+ */
+
+export interface WorkspaceFixture {
+  label: string;
+  kind: "healthy" | "repaired" | "legacy" | "dependency-heavy";
+  payload: Record<string, unknown>;
+}
+
+export const HEALTHY_FIXTURE: WorkspaceFixture = {
+  label: "healthy-workspace",
+  kind: "healthy",
+  payload: {
+    id: "ws-healthy-001",
+    name: "Healthy Workspace",
+    schemaVersion: 3,
+    selectedNetwork: "testnet",
+    savedContracts: [{ contractId: "CABC123", network: "testnet" }],
+    savedInteractions: [{ functionName: "increment", argumentsJson: { value: 1 } }],
+    artifacts: [{ kind: "wasm", name: "counter", network: "testnet", hash: "abc123", metadata: null }],
+  },
+};
+
+export const REPAIRED_FIXTURE: WorkspaceFixture = {
+  label: "repaired-workspace",
+  kind: "repaired",
+  payload: {
+    id: "ws-repaired-001",
+    name: "Repaired Workspace",
+    schemaVersion: 3,
+    selectedNetwork: "testnet",
+    savedContracts: [],
+    savedInteractions: [],
+    artifacts: [],
+    _repaired: true,
+    _repairedFields: ["savedContracts", "savedInteractions"],
+  },
+};
+
+export const LEGACY_FIXTURE: WorkspaceFixture = {
+  label: "legacy-workspace",
+  kind: "legacy",
+  payload: {
+    id: "ws-legacy-001",
+    name: "Legacy Workspace",
+    schemaVersion: 1,
+    network: "testnet",
+    contracts: [{ id: "CXYZ789", net: "testnet" }],
+  },
+};
+
+export const DEPENDENCY_HEAVY_FIXTURE: WorkspaceFixture = {
+  label: "dependency-heavy-workspace",
+  kind: "dependency-heavy",
+  payload: {
+    id: "ws-deps-001",
+    name: "Dependency Heavy Workspace",
+    schemaVersion: 3,
+    selectedNetwork: "testnet",
+    savedContracts: Array.from({ length: 10 }, (_, i) => ({ contractId: `CDEP${i}`, network: "testnet" })),
+    savedInteractions: Array.from({ length: 10 }, (_, i) => ({ functionName: `fn_${i}`, argumentsJson: { i } })),
+    artifacts: Array.from({ length: 5 }, (_, i) => ({ kind: "wasm", name: `contract_${i}`, network: "testnet", hash: `hash${i}`, metadata: null })),
+  },
+};
+
+export const ALL_FIXTURES: WorkspaceFixture[] = [
+  HEALTHY_FIXTURE,
+  REPAIRED_FIXTURE,
+  LEGACY_FIXTURE,
+  DEPENDENCY_HEAVY_FIXTURE,
+];


### PR DESCRIPTION
Closes #291, closes #292, closes #293, closes #297

- **BE-019 (#293)**: Added `workspace-validation-warnings.ts` — structured import/export validation returning typed `ApiWarning` arrays so clients distinguish repaired fields from unrecoverable failures without string parsing.
- **BE-020 (#292)**: Added `revision-conflict.ts` — typed `RevisionConflictPayload` with expected/actual revision and a human hint, keeping conflict responses distinct from generic errors.
- **BE-021 (#291)**: Added `deploy-result-decoder.ts` — normalizes raw deploy results into `DeployResultMeta` with safe fallback so browser consumers drop XDR handling.
- **DEVOPS-023 (#297)**: Added `workspace-round-trip-fixtures.ts` — four curated fixtures (healthy, repaired, legacy, dependency-heavy) for stable regression testing of import/export round-trips.