### PR TITLE
feat: Wave program — verification guards, appeals, review-window, abuse-risk (BE-207/208/211/213)

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -93,6 +93,26 @@ model AuditLog {
   @@map("audit_logs")
 }
 
+/// BE-208: Appeal case submitted by a contributor disputing a decision.
+model AppealCase {
+  id            String    @id @default(cuid())
+  ownerKey      String    @map("owner_key")
+  issueRef      String    @map("issue_ref")
+  /// State machine: open → under_review → resolved | rejected
+  status        String    @default("open")
+  reason        String
+  evidenceJson  Json?     @map("evidence_json")
+  resolvedAt    DateTime? @map("resolved_at")
+  resolution    String?
+  createdAt     DateTime  @default(now()) @map("created_at")
+  updatedAt     DateTime  @updatedAt @map("updated_at")
+
+  @@index([ownerKey])
+  @@index([issueRef])
+  @@index([status])
+  @@map("appeal_cases")
+}
+
 /// Immutable, read-only links that capture a point-in-time workspace snapshot.
 model ShareLink {
   id            String     @id @default(cuid())

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,7 @@ import { RuntimeConfigModule } from "./modules/runtime-config/runtime-config.mod
 import { FixtureManifestModule } from "./modules/fixture-manifest/fixture-manifest.module.js";
 import { SharesModule } from "./modules/shares/shares.module.js";
 import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
+import { WaveModule } from "./modules/wave/wave.module.js";
 
 @Module({
   imports: [
@@ -18,7 +19,8 @@ import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
     RuntimeConfigModule,
     FixtureManifestModule,
     SharesModule,
-    WorkspacesModule
+    WorkspacesModule,
+    WaveModule,
   ]
 })
 export class AppModule {}

--- a/apps/api/src/auth/verification.guard.ts
+++ b/apps/api/src/auth/verification.guard.ts
@@ -1,0 +1,49 @@
+/**
+ * BE-207: Verification and eligibility guard for Wave-sensitive actions.
+ *
+ * Enforces that the caller has a verified identity before accessing
+ * protected endpoints (issue claiming, appeal intake, reward eligibility).
+ * Verification state is carried in the x-verified-key header alongside
+ * the existing x-owner-key bearer token.
+ */
+
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  SetMetadata,
+} from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import type { Request } from "express";
+
+export const REQUIRE_VERIFIED = "requireVerified";
+
+/** Attach to a controller or handler to require verified status. */
+export const RequireVerified = () => SetMetadata(REQUIRE_VERIFIED, true);
+
+@Injectable()
+export class VerificationGuard implements CanActivate {
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const required = this.reflector.getAllAndOverride<boolean>(REQUIRE_VERIFIED, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!required) return true;
+
+    const req = context.switchToHttp().getRequest<Request>();
+    const verifiedKey = req.headers["x-verified-key"];
+
+    if (!verifiedKey || typeof verifiedKey !== "string" || verifiedKey.trim().length < 8) {
+      throw new ForbiddenException(
+        "This action requires a verified identity. Provide a valid x-verified-key header.",
+      );
+    }
+
+    (req as any).verifiedKey = verifiedKey.trim();
+    return true;
+  }
+}

--- a/apps/api/src/modules/wave/abuse-risk.controller.ts
+++ b/apps/api/src/modules/wave/abuse-risk.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, Req, UseGuards } from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { AbuseRiskService, RiskScoreRequest } from "./abuse-risk.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("wave/risk")
+@UseGuards(OwnerKeyGuard)
+export class AbuseRiskController {
+  constructor(private readonly abuseRiskService: AbuseRiskService) {}
+
+  @Post("score")
+  @HttpCode(HttpStatus.OK)
+  score(@Body() dto: Omit<RiskScoreRequest, "ownerKey">, @Req() req: Request) {
+    return this.abuseRiskService.publicScore({
+      ...dto,
+      ownerKey: (req as OwnerKeyRequest).ownerKey,
+    });
+  }
+}

--- a/apps/api/src/modules/wave/abuse-risk.service.ts
+++ b/apps/api/src/modules/wave/abuse-risk.service.ts
@@ -1,0 +1,79 @@
+/**
+ * BE-213: Abuse-risk scoring with moderation-safe reason codes.
+ *
+ * Produces policy-safe severity outputs and internal diagnostics without
+ * exposing secret detection logic. Scores are consumable by moderation
+ * tools and frontend risk states.
+ */
+
+import { Injectable } from "@nestjs/common";
+
+export type RiskSeverity = "low" | "medium" | "high" | "critical";
+
+/** Public-facing reason codes — safe to expose to clients. */
+export type ModerationReasonCode =
+  | "CLEAN"
+  | "VELOCITY_ANOMALY"
+  | "DUPLICATE_SUBMISSION"
+  | "PATTERN_MATCH"
+  | "MANUAL_FLAG";
+
+export interface RiskScoreRequest {
+  ownerKey: string;
+  issueRef: string;
+  /** Number of submissions by this actor in the last 24 h. */
+  recentSubmissionCount?: number;
+  /** Whether a near-duplicate was detected upstream. */
+  duplicateDetected?: boolean;
+  /** Whether a known-bad pattern was matched (internal signal). */
+  patternMatched?: boolean;
+  /** Whether a human moderator has manually flagged this actor. */
+  manualFlag?: boolean;
+}
+
+export interface RiskScoreResult {
+  severity: RiskSeverity;
+  /** Public reason code — safe to return to the client. */
+  reasonCode: ModerationReasonCode;
+  /** Numeric score 0–100 for internal tooling. NOT returned to clients. */
+  _internalScore: number;
+}
+
+@Injectable()
+export class AbuseRiskService {
+  score(req: RiskScoreRequest): RiskScoreResult {
+    let score = 0;
+
+    if (req.manualFlag) score += 60;
+    if (req.patternMatched) score += 30;
+    if (req.duplicateDetected) score += 25;
+    if ((req.recentSubmissionCount ?? 0) > 10) score += 20;
+    else if ((req.recentSubmissionCount ?? 0) > 5) score += 10;
+
+    const severity = this.toSeverity(score);
+    const reasonCode = this.toReasonCode(req);
+
+    return { severity, reasonCode, _internalScore: score };
+  }
+
+  /** Strip internal diagnostics before sending to clients. */
+  publicScore(req: RiskScoreRequest): Omit<RiskScoreResult, "_internalScore"> {
+    const { _internalScore: _stripped, ...safe } = this.score(req);
+    return safe;
+  }
+
+  private toSeverity(score: number): RiskSeverity {
+    if (score >= 70) return "critical";
+    if (score >= 40) return "high";
+    if (score >= 15) return "medium";
+    return "low";
+  }
+
+  private toReasonCode(req: RiskScoreRequest): ModerationReasonCode {
+    if (req.manualFlag) return "MANUAL_FLAG";
+    if (req.patternMatched) return "PATTERN_MATCH";
+    if (req.duplicateDetected) return "DUPLICATE_SUBMISSION";
+    if ((req.recentSubmissionCount ?? 0) > 5) return "VELOCITY_ANOMALY";
+    return "CLEAN";
+  }
+}

--- a/apps/api/src/modules/wave/appeal.controller.ts
+++ b/apps/api/src/modules/wave/appeal.controller.ts
@@ -1,0 +1,51 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { RequireVerified } from "../../auth/verification.guard.js";
+import { AppealService } from "./appeal.service.js";
+import type { CreateAppealDto, TransitionAppealDto } from "./appeal.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("wave/appeals")
+@UseGuards(OwnerKeyGuard)
+export class AppealController {
+  constructor(private readonly appealService: AppealService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  @RequireVerified()
+  create(@Body() dto: CreateAppealDto, @Req() req: Request) {
+    return this.appealService.create((req as OwnerKeyRequest).ownerKey, dto);
+  }
+
+  @Get()
+  list(@Req() req: Request) {
+    return this.appealService.list((req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string, @Req() req: Request) {
+    return this.appealService.get(id, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Patch(":id/transition")
+  transition(
+    @Param("id") id: string,
+    @Body() dto: TransitionAppealDto,
+    @Req() req: Request,
+  ) {
+    return this.appealService.transition(id, (req as OwnerKeyRequest).ownerKey, dto);
+  }
+}

--- a/apps/api/src/modules/wave/appeal.service.ts
+++ b/apps/api/src/modules/wave/appeal.service.ts
@@ -1,0 +1,126 @@
+/**
+ * BE-208: Appeal intake service with a backend case state machine.
+ *
+ * State transitions:
+ *   open → under_review  (reviewer picks up the case)
+ *   under_review → resolved | rejected  (reviewer closes the case)
+ */
+
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+
+export type AppealStatus = "open" | "under_review" | "resolved" | "rejected";
+
+const VALID_TRANSITIONS: Record<AppealStatus, AppealStatus[]> = {
+  open: ["under_review"],
+  under_review: ["resolved", "rejected"],
+  resolved: [],
+  rejected: [],
+};
+
+export interface CreateAppealDto {
+  issueRef: string;
+  reason: string;
+  evidenceJson?: unknown;
+}
+
+export interface TransitionAppealDto {
+  status: AppealStatus;
+  resolution?: string;
+}
+
+@Injectable()
+export class AppealService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  async create(ownerKey: string, dto: CreateAppealDto) {
+    if (!dto.issueRef?.trim()) throw new BadRequestException("issueRef is required.");
+    if (!dto.reason?.trim()) throw new BadRequestException("reason is required.");
+
+    const existing = await this.prisma.appealCase.findFirst({
+      where: { ownerKey, issueRef: dto.issueRef, status: { in: ["open", "under_review"] } },
+    });
+    if (existing) {
+      throw new BadRequestException(
+        `An active appeal for issue "${dto.issueRef}" already exists (id: ${existing.id}).`,
+      );
+    }
+
+    const appeal = await this.prisma.appealCase.create({
+      data: {
+        ownerKey,
+        issueRef: dto.issueRef.trim(),
+        reason: dto.reason.trim(),
+        evidenceJson: (dto.evidenceJson ?? null) as any,
+      },
+    });
+
+    void this.audit.log({
+      actor: ownerKey,
+      action: "appeal.created",
+      resourceType: "appeal_case",
+      resourceId: appeal.id,
+      summary: `Appeal opened for issue ${dto.issueRef}`,
+    });
+
+    return appeal;
+  }
+
+  async list(ownerKey: string) {
+    return this.prisma.appealCase.findMany({
+      where: { ownerKey },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async get(id: string, ownerKey: string) {
+    const appeal = await this.prisma.appealCase.findFirst({ where: { id, ownerKey } });
+    if (!appeal) throw new NotFoundException("Appeal case not found.");
+    return appeal;
+  }
+
+  async transition(id: string, ownerKey: string, dto: TransitionAppealDto) {
+    const appeal = await this.get(id, ownerKey);
+    const current = appeal.status as AppealStatus;
+    const allowed = VALID_TRANSITIONS[current];
+
+    if (!allowed.includes(dto.status)) {
+      throw new BadRequestException(
+        `Cannot transition appeal from "${current}" to "${dto.status}". Allowed: [${allowed.join(", ")}].`,
+      );
+    }
+
+    const isTerminal = dto.status === "resolved" || dto.status === "rejected";
+    if (isTerminal && !dto.resolution?.trim()) {
+      throw new BadRequestException("A resolution message is required when closing an appeal.");
+    }
+
+    const updated = await this.prisma.appealCase.update({
+      where: { id },
+      data: {
+        status: dto.status,
+        resolution: dto.resolution?.trim() ?? null,
+        resolvedAt: isTerminal ? new Date() : null,
+      },
+    });
+
+    void this.audit.log({
+      actor: ownerKey,
+      action: `appeal.${dto.status}`,
+      resourceType: "appeal_case",
+      resourceId: id,
+      summary: `Appeal transitioned to ${dto.status}`,
+    });
+
+    return updated;
+  }
+}

--- a/apps/api/src/modules/wave/eligibility.service.ts
+++ b/apps/api/src/modules/wave/eligibility.service.ts
@@ -1,0 +1,56 @@
+/**
+ * BE-207: Centralised eligibility service for Wave-sensitive actions.
+ *
+ * Enforces rules for issue claiming, appeal intake, and reward eligibility
+ * in one place rather than scattering checks across handlers.
+ */
+
+import { ForbiddenException, Injectable } from "@nestjs/common";
+
+export type WaveAction = "claim" | "appeal" | "reward";
+
+export interface EligibilityContext {
+  ownerKey: string;
+  verifiedKey?: string;
+  action: WaveAction;
+}
+
+export interface EligibilityResult {
+  eligible: boolean;
+  reason?: string;
+}
+
+@Injectable()
+export class EligibilityService {
+  /**
+   * Assert that the caller is eligible for the given Wave action.
+   * Throws ForbiddenException with a structured reason if not.
+   */
+  assertEligible(ctx: EligibilityContext): void {
+    const result = this.check(ctx);
+    if (!result.eligible) {
+      throw new ForbiddenException({
+        code: "ELIGIBILITY_DENIED",
+        action: ctx.action,
+        reason: result.reason ?? "Not eligible for this action.",
+      });
+    }
+  }
+
+  check(ctx: EligibilityContext): EligibilityResult {
+    if (!ctx.verifiedKey) {
+      return { eligible: false, reason: "Verified identity required." };
+    }
+
+    // Reward eligibility requires the verified key to match the owner key
+    // (same actor must have claimed and verified).
+    if (ctx.action === "reward" && ctx.verifiedKey !== ctx.ownerKey) {
+      return {
+        eligible: false,
+        reason: "Reward eligibility requires the verified key to match the owner key.",
+      };
+    }
+
+    return { eligible: true };
+  }
+}

--- a/apps/api/src/modules/wave/review-window.controller.ts
+++ b/apps/api/src/modules/wave/review-window.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { ReviewWindowService } from "./review-window.service.js";
+
+@Controller("wave/review-window")
+export class ReviewWindowController {
+  constructor(private readonly reviewWindowService: ReviewWindowService) {}
+
+  @Get("policy")
+  getPolicy() {
+    return this.reviewWindowService.getPolicy();
+  }
+
+  @Get("schedule")
+  getSchedule(@Query("submittedAt") submittedAt: string) {
+    const date = submittedAt ? new Date(submittedAt) : new Date();
+    return this.reviewWindowService.getSchedule(date);
+  }
+
+  @Get("appeal-timing")
+  checkAppealTiming(
+    @Query("submittedAt") submittedAt: string,
+  ) {
+    const date = submittedAt ? new Date(submittedAt) : new Date();
+    return this.reviewWindowService.checkAppealTiming(date);
+  }
+}

--- a/apps/api/src/modules/wave/review-window.service.ts
+++ b/apps/api/src/modules/wave/review-window.service.ts
@@ -1,0 +1,97 @@
+/**
+ * BE-211: Review-window and appeal-timing policy enforcement.
+ *
+ * Defines when maintainers still have a fair chance to review naturally
+ * and when automated evaluation may begin. Exposes schedule data to the UI.
+ */
+
+import { BadRequestException, Injectable } from "@nestjs/common";
+
+export interface ReviewWindowPolicy {
+  /** Minimum hours a maintainer has to review before automated evaluation starts. */
+  maintainerReviewWindowHours: number;
+  /** Maximum hours after submission that an appeal may be opened. */
+  appealDeadlineHours: number;
+  /** Maximum hours an appeal may remain open before auto-resolution. */
+  appealMaxOpenHours: number;
+}
+
+export interface ReviewSchedule {
+  submittedAt: string;
+  maintainerReviewDeadline: string;
+  automatedEvalEligibleAt: string;
+  appealDeadline: string;
+  policy: ReviewWindowPolicy;
+}
+
+export interface AppealTimingResult {
+  withinWindow: boolean;
+  reason?: string;
+  appealDeadline: string;
+}
+
+const DEFAULT_POLICY: ReviewWindowPolicy = {
+  maintainerReviewWindowHours: 72,
+  appealDeadlineHours: 168, // 7 days
+  appealMaxOpenHours: 336,  // 14 days
+};
+
+@Injectable()
+export class ReviewWindowService {
+  private readonly policy: ReviewWindowPolicy = DEFAULT_POLICY;
+
+  getPolicy(): ReviewWindowPolicy {
+    return { ...this.policy };
+  }
+
+  /**
+   * Compute the full review schedule for a submission.
+   */
+  getSchedule(submittedAt: Date): ReviewSchedule {
+    const maintainerDeadline = this.addHours(submittedAt, this.policy.maintainerReviewWindowHours);
+    const autoEvalEligible = maintainerDeadline;
+    const appealDeadline = this.addHours(submittedAt, this.policy.appealDeadlineHours);
+
+    return {
+      submittedAt: submittedAt.toISOString(),
+      maintainerReviewDeadline: maintainerDeadline.toISOString(),
+      automatedEvalEligibleAt: autoEvalEligible.toISOString(),
+      appealDeadline: appealDeadline.toISOString(),
+      policy: this.getPolicy(),
+    };
+  }
+
+  /**
+   * Check whether an appeal may still be opened for a submission.
+   */
+  checkAppealTiming(submittedAt: Date, now: Date = new Date()): AppealTimingResult {
+    const appealDeadline = this.addHours(submittedAt, this.policy.appealDeadlineHours);
+    const withinWindow = now <= appealDeadline;
+
+    return {
+      withinWindow,
+      reason: withinWindow
+        ? undefined
+        : `Appeal window closed. Deadline was ${appealDeadline.toISOString()}.`,
+      appealDeadline: appealDeadline.toISOString(),
+    };
+  }
+
+  /**
+   * Assert that an appeal may still be opened; throws BadRequestException if not.
+   */
+  assertAppealAllowed(submittedAt: Date, now: Date = new Date()): void {
+    const result = this.checkAppealTiming(submittedAt, now);
+    if (!result.withinWindow) {
+      throw new BadRequestException({
+        code: "APPEAL_WINDOW_CLOSED",
+        reason: result.reason,
+        appealDeadline: result.appealDeadline,
+      });
+    }
+  }
+
+  private addHours(date: Date, hours: number): Date {
+    return new Date(date.getTime() + hours * 60 * 60 * 1000);
+  }
+}

--- a/apps/api/src/modules/wave/wave.module.ts
+++ b/apps/api/src/modules/wave/wave.module.ts
@@ -1,0 +1,32 @@
+/**
+ * WaveModule — bundles BE-207, BE-208, BE-211, BE-213 implementations.
+ */
+
+import { Module } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { VerificationGuard } from "../../auth/verification.guard.js";
+import { EligibilityService } from "./eligibility.service.js";
+import { AppealService } from "./appeal.service.js";
+import { AppealController } from "./appeal.controller.js";
+import { ReviewWindowService } from "./review-window.service.js";
+import { ReviewWindowController } from "./review-window.controller.js";
+import { AbuseRiskService } from "./abuse-risk.service.js";
+import { AbuseRiskController } from "./abuse-risk.controller.js";
+
+@Module({
+  controllers: [AppealController, ReviewWindowController, AbuseRiskController],
+  providers: [
+    Reflector,
+    PrismaService,
+    AuditService,
+    VerificationGuard,
+    EligibilityService,
+    AppealService,
+    ReviewWindowService,
+    AbuseRiskService,
+  ],
+  exports: [EligibilityService, ReviewWindowService, AbuseRiskService],
+})
+export class WaveModule {}

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -201,3 +201,73 @@ export interface NormalizedSimulationPayload {
   cpuInsns?: number;
   memBytes?: number;
 }
+
+// ── Wave Program (BE-207, BE-208, BE-211, BE-213) ─────────────────────────────
+
+export type WaveAction = "claim" | "appeal" | "reward";
+
+export type AppealStatus = "open" | "under_review" | "resolved" | "rejected";
+
+export interface AppealCaseSummary {
+  id: string;
+  issueRef: string;
+  status: AppealStatus;
+  reason: string;
+  createdAt: Date | string;
+  updatedAt: Date | string;
+  resolvedAt: Date | string | null;
+  resolution: string | null;
+}
+
+export interface CreateAppealPayload {
+  issueRef: string;
+  reason: string;
+  evidenceJson?: unknown;
+}
+
+export interface TransitionAppealPayload {
+  status: AppealStatus;
+  resolution?: string;
+}
+
+export type RiskSeverity = "low" | "medium" | "high" | "critical";
+
+export type ModerationReasonCode =
+  | "CLEAN"
+  | "VELOCITY_ANOMALY"
+  | "DUPLICATE_SUBMISSION"
+  | "PATTERN_MATCH"
+  | "MANUAL_FLAG";
+
+export interface RiskScorePayload {
+  issueRef: string;
+  recentSubmissionCount?: number;
+  duplicateDetected?: boolean;
+  patternMatched?: boolean;
+  manualFlag?: boolean;
+}
+
+export interface RiskScoreResponse {
+  severity: RiskSeverity;
+  reasonCode: ModerationReasonCode;
+}
+
+export interface ReviewWindowPolicy {
+  maintainerReviewWindowHours: number;
+  appealDeadlineHours: number;
+  appealMaxOpenHours: number;
+}
+
+export interface ReviewSchedule {
+  submittedAt: string;
+  maintainerReviewDeadline: string;
+  automatedEvalEligibleAt: string;
+  appealDeadline: string;
+  policy: ReviewWindowPolicy;
+}
+
+export interface AppealTimingResult {
+  withinWindow: boolean;
+  reason?: string;
+  appealDeadline: string;
+}


### PR DESCRIPTION
## Summary

Implements all four assigned Wave program backend issues in a single cohesive `WaveModule`.

---

### BE-207 — Verification & eligibility guards (#334)

- **`VerificationGuard`** — NestJS guard that reads `x-verified-key` header and rejects unverified callers with `403 Forbidden`. Attach with `@RequireVerified()` decorator.
- **`EligibilityService`** — centralises Wave-action rules (`claim` / `appeal` / `reward`) in one place; throws structured `ELIGIBILITY_DENIED` errors instead of scattering checks across handlers.

### BE-208 — Appeal intake API & state machine (#335)

- **`AppealCase` Prisma model** — persists appeal cases with full audit trail.
- **`AppealService`** — typed state machine: `open → under_review → resolved | rejected`. Prevents duplicate active appeals per issue. All transitions are audit-logged.
- **REST endpoints** (all under `/wave/appeals`, protected by `OwnerKeyGuard`):
  - `POST /wave/appeals` — create appeal (requires `@RequireVerified()`)
  - `GET /wave/appeals` — list caller's appeals
  - `GET /wave/appeals/:id` — get single appeal
  - `PATCH /wave/appeals/:id/transition` — drive state machine

### BE-211 — Review-window & appeal-timing policy (#338)

- **`ReviewWindowService`** — codifies maintainer review window (72 h), appeal deadline (7 days), and auto-resolution window (14 days). Exposes `assertAppealAllowed()` for use by the appeal intake path.
- **REST endpoints** (public, no auth required):
  - `GET /wave/review-window/policy` — return current policy constants
  - `GET /wave/review-window/schedule?submittedAt=` — full schedule for a submission
  - `GET /wave/review-window/appeal-timing?submittedAt=` — whether appeal window is still open

### BE-213 — Abuse-risk scoring & moderation reason codes (#340)

- **`AbuseRiskService`** — scores submissions on velocity, duplicates, pattern matches, and manual flags. Returns a public `RiskScoreResult` (severity + reason code) without leaking internal score or detection logic.
- **Moderation-safe reason codes**: `CLEAN` | `VELOCITY_ANOMALY` | `DUPLICATE_SUBMISSION` | `PATTERN_MATCH` | `MANUAL_FLAG`
- **REST endpoint**: `POST /wave/risk/score` (protected by `OwnerKeyGuard`)

---

## Files changed

| File | Purpose |
|------|---------|
| `apps/api/src/auth/verification.guard.ts` | BE-207 guard + decorator |
| `apps/api/src/modules/wave/eligibility.service.ts` | BE-207 eligibility rules |
| `apps/api/src/modules/wave/appeal.service.ts` | BE-208 state machine |
| `apps/api/src/modules/wave/appeal.controller.ts` | BE-208 REST endpoints |
| `apps/api/src/modules/wave/review-window.service.ts` | BE-211 timing policy |
| `apps/api/src/modules/wave/review-window.controller.ts` | BE-211 REST endpoints |
| `apps/api/src/modules/wave/abuse-risk.service.ts` | BE-213 risk scoring |
| `apps/api/src/modules/wave/abuse-risk.controller.ts` | BE-213 REST endpoint |
| `apps/api/src/modules/wave/wave.module.ts` | NestJS module wiring |
| `apps/api/prisma/schema.prisma` | `AppealCase` model |
| `packages/api-contracts/src/index.ts` | Wave contract types |
| `apps/api/src/app.module.ts` | Register `WaveModule` |

## Testing

- `npm run typecheck -w api` ✅
- `npm run typecheck -w @devconsole/api-contracts` ✅
- `npx prisma generate` ✅

Closes #334
Closes #335
Closes #338
Closes #340