### PR TITLE
feat(devops): config promotion, branch protection, flaky quarantine, backup drill

### DIFF
--- a/.github/flaky-quarantine.json
+++ b/.github/flaky-quarantine.json
@@ -1,0 +1,4 @@
+{
+  "quarantined": [],
+  "graduated": []
+}

--- a/.github/workflows/backup-restore-drill.yml
+++ b/.github/workflows/backup-restore-drill.yml
@@ -1,0 +1,69 @@
+name: Backup / Restore Drill
+
+on:
+  # Run weekly to verify backups are restorable
+  schedule:
+    - cron: "0 3 * * 0"  # Every Sunday at 03:00 UTC
+
+  # Allow manual trigger
+  workflow_dispatch:
+    inputs:
+      db_path:
+        description: "Path to the SQLite database (relative to repo root)"
+        required: false
+        default: "apps/api/prisma/dev.db"
+
+jobs:
+  drill:
+    name: Backup and Restore Drill
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate Prisma client
+        run: npm run prisma:generate -w api
+
+      - name: Seed a fresh database for drill
+        run: |
+          cd apps/api
+          npx prisma db push --force-reset
+          npx prisma db seed
+          cd ../..
+        env:
+          DATABASE_URL: "file:./prisma/dev.db"
+
+      - name: Run backup/restore drill
+        run: |
+          bash scripts/backup-restore-drill.sh drill \
+            --db "${DB_PATH:-apps/api/prisma/dev.db}" \
+            --out .backups
+        env:
+          DB_PATH: ${{ github.event.inputs.db_path || 'apps/api/prisma/dev.db' }}
+
+      - name: Upload backup artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: drill-backup-${{ github.run_id }}
+          path: .backups/
+          retention-days: 30
+
+      - name: List available backups
+        if: always()
+        run: bash scripts/backup-restore-drill.sh list --out .backups
+
+      - name: Annotate failure
+        if: failure()
+        run: |
+          echo "::error::Backup/restore drill failed. The database may not be reliably restorable. Check the drill output above."

--- a/.github/workflows/flaky-quarantine.yml
+++ b/.github/workflows/flaky-quarantine.yml
@@ -1,0 +1,79 @@
+name: Flaky Check Quarantine
+
+on:
+  # Run weekly to catch newly-flaky jobs and flag overdue quarantines
+  schedule:
+    - cron: "0 6 * * 1"  # Every Monday at 06:00 UTC
+
+  # Allow manual trigger with optional job name to detect
+  workflow_dispatch:
+    inputs:
+      job_name:
+        description: "Job name to run flaky detection on (leave blank for report only)"
+        required: false
+        default: ""
+      run_count:
+        description: "Number of times to re-run the job for detection"
+        required: false
+        default: "5"
+
+jobs:
+  quarantine-report:
+    name: Quarantine Report
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Report quarantine status
+        id: report
+        run: |
+          bash scripts/quarantine-flaky-check.sh report
+        continue-on-error: true
+
+      - name: Annotate overdue quarantines
+        if: steps.report.outcome == 'failure'
+        run: |
+          echo "::warning::One or more quarantined checks are overdue for review. See the report above."
+          bash scripts/quarantine-flaky-check.sh list
+
+      - name: Upload quarantine state
+        uses: actions/upload-artifact@v4
+        with:
+          name: flaky-quarantine-state
+          path: .github/flaky-quarantine.json
+          retention-days: 90
+
+  detect-flaky:
+    name: Detect Flaky Job
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.job_name != ''
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run flaky detection
+        id: detect
+        run: |
+          bash scripts/quarantine-flaky-check.sh detect \
+            "${{ github.event.inputs.job_name }}" \
+            "${{ github.event.inputs.run_count }}"
+        continue-on-error: true
+
+      - name: Commit updated quarantine state
+        if: steps.detect.outcome != 'success'
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/flaky-quarantine.json
+          git diff --cached --quiet || git commit -m "chore(ci): quarantine flaky job ${{ github.event.inputs.job_name }} [skip ci]"
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 
 # Optional: coverage
 coverage
+.backups/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,25 @@ soroban-dev-console/
 - `/src/auth` - Authentication guards
 - `/prisma` - Database schema, migrations, and seeds
 
+## Branch Protection and Required Checks
+
+The `main` branch is fully protected. **Direct pushes are rejected** — all changes must go through a pull request.
+
+A PR cannot be merged until all applicable CI jobs pass:
+
+| Job | Runs when |
+|-----|-----------|
+| `Web` | `apps/web/**` or `packages/ui/**` changed |
+| `API` | `apps/api/**` or `packages/api-contracts/**` changed |
+| `Package Validation` | `packages/**` changed |
+| `Contracts` | `contracts/**` changed |
+| `DevOps` | `scripts/**`, `.env.example`, `README.md`, or `docs/architecture.md` changed |
+| `E2E Tests` | `apps/web/e2e/**` changed or when `Web` runs |
+
+At least **1 approving review** is required. Reviews are dismissed when new commits are pushed.
+
+See [docs/branch-protection.md](./docs/branch-protection.md) for the full reference including the release process and hotfix workflow.
+
 ## Pull Request Process
 
 1. **Create a branch** from `main`:
@@ -180,10 +199,9 @@ soroban-dev-console/
    - Add screenshots for UI changes
    - Note any breaking changes
 
-Direct pushes to `main` may be blocked by branch protection. If that happens,
-push your branch and open a PR instead of trying to bypass the protection.
-
 7. **Address review feedback** promptly
+
+> **Merge strategy**: Squash merge is preferred for feature and fix branches to keep `main` history linear. See [docs/branch-protection.md](./docs/branch-protection.md) for the full merge and release discipline.
 
 ## Areas We Need Help
 

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -30,7 +30,8 @@ SOROBAN_BUILD_IMAGE="stellar/stellar-cli:latest"
 # ── Runtime Mode ──────────────────────────────────────────────────────────────
 # Controls which env vars are required vs optional at startup.
 # Values: local (default) | demo | ci
-# RUNTIME_MODE="local"
+# See docs/config-promotion.md for the full promotion workflow.
+RUNTIME_MODE="local"
 
 # ── Security Configuration ───────────────────────────────────────────────────
 # DEVOPS-002: Security headers are automatically applied:

--- a/docs/backup-restore-drill.md
+++ b/docs/backup-restore-drill.md
@@ -1,0 +1,114 @@
+# Backup and Restore Drill
+
+> DEVOPS-214: Automated process for verifying that operational data can actually be restored, not just backed up.
+
+## Overview
+
+The backup/restore drill creates a timestamped SQLite backup, restores it to a temporary location, and verifies that all row counts match. This catches silent corruption, incomplete backups, and restore failures before they become incidents.
+
+## Script
+
+```bash
+scripts/backup-restore-drill.sh <command> [options]
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `drill` | Full cycle: backup → restore → verify (default) |
+| `backup` | Create a backup only |
+| `restore <file>` | Restore from a specific backup file |
+| `list` | List available backups |
+| `prune` | Remove old backups, keep N most recent |
+
+### Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--db <path>` | `apps/api/prisma/dev.db` | Path to the SQLite database |
+| `--out <dir>` | `.backups` | Directory for backup files |
+| `--keep <n>` | `10` | Number of backups to retain on prune |
+
+### Environment Variables
+
+The same options can be set via environment variables:
+
+```bash
+export DB_PATH=apps/api/prisma/dev.db
+export BACKUP_DIR=.backups
+export KEEP_COUNT=10
+```
+
+## Running the Drill
+
+```bash
+# Full drill (backup → restore → verify)
+./scripts/backup-restore-drill.sh drill
+
+# Drill against a specific database
+./scripts/backup-restore-drill.sh drill --db apps/api/prisma/demo.db --out .backups/demo
+
+# Create a backup only
+./scripts/backup-restore-drill.sh backup
+
+# Restore from a specific backup
+./scripts/backup-restore-drill.sh restore .backups/backup-20250115T100000Z.db
+
+# List all backups
+./scripts/backup-restore-drill.sh list
+
+# Prune old backups, keep 5 most recent
+./scripts/backup-restore-drill.sh prune --keep 5
+```
+
+## What the Drill Verifies
+
+1. **Source integrity**: `PRAGMA integrity_check` on the live database.
+2. **Backup creation**: SQLite's online backup API (safe for live databases).
+3. **Backup integrity**: `PRAGMA integrity_check` on the backup file.
+4. **Restore**: Copy backup to a temporary location.
+5. **Restore integrity**: `PRAGMA integrity_check` on the restored file.
+6. **Row count parity**: All tables (`workspaces`, `saved_contracts`, `saved_interactions`, `audit_logs`, `share_links`) must have identical row counts before and after.
+
+If any step fails, the script exits with a non-zero status and prints an actionable error message.
+
+## Automated Workflow
+
+The `backup-restore-drill.yml` workflow runs every Sunday at 03:00 UTC and:
+
+1. Seeds a fresh database using `prisma db seed`.
+2. Runs the full drill.
+3. Uploads the backup as a workflow artifact (retained 30 days).
+4. Posts a `::error::` annotation if the drill fails.
+
+You can also trigger it manually from the Actions tab, optionally specifying a custom database path.
+
+## Backup Storage
+
+Backups are written to `.backups/` by default. This directory is git-ignored. For production deployments, configure `BACKUP_DIR` to point to a durable storage location (e.g., a mounted volume or an S3-compatible bucket via a pre/post hook).
+
+## Restore Safety
+
+The `restore` command always saves a copy of the current database as `<db>.pre-restore-<timestamp>` before overwriting it. If the restored database fails its integrity check, the script automatically reverts to the pre-restore copy.
+
+## Retention Policy
+
+Run `prune` periodically to avoid unbounded disk usage:
+
+```bash
+# Keep the 10 most recent backups
+./scripts/backup-restore-drill.sh prune --keep 10
+```
+
+The CI workflow does not auto-prune local backups. Prune manually or add a cron job for long-running environments.
+
+## Failure Response
+
+If the drill fails in CI:
+
+1. Check the workflow logs for the specific step that failed.
+2. Download the backup artifact and inspect it locally: `sqlite3 <backup-file> "PRAGMA integrity_check;"`
+3. If the source database is corrupt, restore from the most recent passing backup.
+4. If the backup process itself is failing, check disk space and SQLite version.
+5. Open an issue with the `[DEVOPS]` label and link to the failed workflow run.

--- a/docs/branch-protection.md
+++ b/docs/branch-protection.md
@@ -1,0 +1,88 @@
+# Branch Protection, Required Checks, and Release Discipline
+
+> DEVOPS-211: Authoritative reference for the merge model and CI gate requirements.
+
+## Protected Branches
+
+| Branch | Protection level |
+|--------|-----------------|
+| `main` | Fully protected — no direct pushes; all changes via PR |
+
+Direct pushes to `main` are rejected. All work must go through a pull request, regardless of contributor role.
+
+## Required Status Checks
+
+A PR cannot be merged until **all** of the following CI jobs pass:
+
+| Job | Trigger condition |
+|-----|-------------------|
+| `Web` | Any change under `apps/web/**` or `packages/ui/**` |
+| `API` | Any change under `apps/api/**` or `packages/api-contracts/**` |
+| `Package Validation` | Any change under `packages/**` |
+| `Contracts` | Any change under `contracts/**` |
+| `DevOps` | Any change to `scripts/**`, `.env.example` files, `README.md`, or `docs/architecture.md` |
+| `E2E Tests` | Any change to `apps/web/e2e/**` or when `Web` runs |
+
+Jobs that are not triggered by a given PR (path-filtered out) are considered passing by default. The `changes` job in `ci.yml` controls which jobs run via `dorny/paths-filter`.
+
+## Review Requirements
+
+- At least **1 approving review** is required before merge.
+- Reviews are dismissed automatically when new commits are pushed to the PR branch.
+- The PR author cannot approve their own PR.
+
+## Merge Strategy
+
+- **Squash merge** is the preferred strategy for feature and fix branches. This keeps `main` history linear and readable.
+- Merge commits are allowed for release branches where preserving individual commits matters.
+- Rebase merges are discouraged — they rewrite SHAs and complicate bisect.
+
+## Branch Naming
+
+| Prefix | Use case |
+|--------|----------|
+| `feat/` | New features |
+| `fix/` | Bug fixes |
+| `docs/` | Documentation-only changes |
+| `refactor/` | Non-functional code changes |
+| `test/` | Test additions or updates |
+| `chore/` | Maintenance, dependency bumps |
+| `release/` | Release preparation branches |
+
+## Release Discipline
+
+### Versioning
+
+This project follows [Semantic Versioning](https://semver.org/):
+
+- **PATCH** (`x.y.Z`): Backwards-compatible bug fixes.
+- **MINOR** (`x.Y.0`): New backwards-compatible features.
+- **MAJOR** (`X.0.0`): Breaking changes.
+
+### Release Process
+
+1. Create a `release/vX.Y.Z` branch from `main`.
+2. Bump the version in `package.json` (root and affected workspaces).
+3. Update `CHANGELOG.md` with the release notes.
+4. Open a PR from `release/vX.Y.Z` → `main`. All required checks must pass.
+5. After merge, tag the commit: `git tag vX.Y.Z && git push origin vX.Y.Z`.
+6. GitHub Actions (or a maintainer) publishes the release from the tag.
+
+### Hotfixes
+
+For urgent fixes to a released version:
+
+1. Branch from the release tag: `git checkout -b fix/critical-bug vX.Y.Z`.
+2. Apply the fix, open a PR to `main`.
+3. After merge, cherry-pick to any active release branches if needed.
+4. Tag a new patch release.
+
+## Bypassing Checks (Emergency Only)
+
+Branch protection bypass is restricted to repository admins and requires a written justification in the PR description. Any bypass must be followed by a post-incident review issue within 48 hours.
+
+## Keeping CI Green
+
+- Never merge a PR with failing required checks.
+- If a check is flaky, follow the quarantine process in [docs/flaky-check-quarantine.md](./flaky-check-quarantine.md) rather than re-running until it passes.
+- The `DevOps` job runs `check-drift` and `check-integrity` — keep these passing to prevent configuration drift.

--- a/docs/config-promotion.md
+++ b/docs/config-promotion.md
@@ -1,0 +1,84 @@
+# Configuration Promotion Guide
+
+> DEVOPS-209: How configuration changes move between `local`, `demo`, and `ci` profiles.
+
+## Overview
+
+The project uses a `RUNTIME_MODE` environment variable to control which variables are required vs optional at startup. This prevents silent misconfiguration when promoting from one environment to the next.
+
+| Profile | `RUNTIME_MODE` value | Purpose |
+|---------|----------------------|---------|
+| Local development | `local` (default) | Full-stack dev on a single machine |
+| Demo / staging | `demo` | Shared preview environment |
+| CI pipeline | `ci` | Automated test runs in GitHub Actions |
+
+## Canonical Source of Truth
+
+All default ports and local URLs live in one place:
+
+```
+packages/api-contracts/src/runtime-defaults.ts
+```
+
+Run `npm run check-drift` after any change to `.env.example` files or `README.md` to verify alignment.
+
+## Profile Differences
+
+### `local`
+- `DATABASE_URL` → SQLite file (`file:./dev.db`)
+- `WEB_ORIGIN` → `http://localhost:3000`
+- `SOROBAN_RPC_MAINNET_URL` → optional (warn only)
+- All other RPC URLs → optional
+
+### `demo`
+- `DATABASE_URL` → persistent SQLite or hosted Postgres
+- `WEB_ORIGIN` → your Vercel/Netlify preview URL
+- `SOROBAN_RPC_TESTNET_URL` → required
+- `SOROBAN_RPC_MAINNET_URL` → required
+
+### `ci`
+- `DATABASE_URL` → `file:./test.db` (ephemeral, created per run)
+- `WEB_ORIGIN` → `http://localhost:3000`
+- All RPC URLs → set to testnet or mocked
+- No secrets required beyond what GitHub Actions provides
+
+## Promotion Workflow
+
+```
+local  ──►  demo  ──►  production-like (ci gate)
+```
+
+1. **local → demo**: Run `scripts/promote-env.sh local demo` to diff and copy non-secret values.
+2. **demo → ci**: CI reads from GitHub Actions secrets; no manual copy needed.
+3. **Validation**: Each profile runs `npm run check-drift` to catch port/URL drift before deployment.
+
+## Using the Promotion Script
+
+```bash
+# Preview what would change (dry-run)
+./scripts/promote-env.sh local demo --dry-run
+
+# Apply promotion (copies non-secret keys, skips *_KEY, *_SECRET, *_TOKEN)
+./scripts/promote-env.sh local demo
+
+# Promote API env only
+./scripts/promote-env.sh local ci --app api
+
+# Promote web env only
+./scripts/promote-env.sh local demo --app web
+```
+
+The script never copies variables whose names contain `KEY`, `SECRET`, or `TOKEN`. Those must be set manually in the target environment or via your secrets manager.
+
+## Adding a New Environment Variable
+
+1. Add it to `apps/api/.env.example` or `apps/web/.env.example` with a comment indicating which profiles require it.
+2. If it contains a port or local URL, add a corresponding constant to `packages/api-contracts/src/runtime-defaults.ts` and update `scripts/check-runtime-drift.ts`.
+3. Run `npm run check-drift` to confirm no drift.
+4. Document the variable in the README environment table.
+
+## CI Environment Setup
+
+GitHub Actions workflows set environment variables via repository secrets and the `env:` block. The `ci.yml` workflow already runs `check-drift` and `check-integrity` in the `devops` job. No additional setup is needed for standard CI runs.
+
+For the `ci` profile specifically, the API startup validates that `RUNTIME_MODE=ci` relaxes mainnet RPC requirements while still enforcing testnet connectivity.

--- a/docs/flaky-check-quarantine.md
+++ b/docs/flaky-check-quarantine.md
@@ -1,0 +1,80 @@
+# Flaky Check Quarantine Process
+
+> DEVOPS-213: How to identify, quarantine, and graduate flaky CI jobs without weakening required protections.
+
+## What Is a Flaky Check?
+
+A flaky check is a CI job that passes and fails non-deterministically on the same code. Flaky checks erode trust in CI and cause unnecessary re-runs. This process provides a structured way to handle them without disabling required protections.
+
+## Quarantine State
+
+All quarantine state lives in `.github/flaky-quarantine.json`. This file is committed to the repository so the quarantine list is visible to all maintainers and tracked in git history.
+
+```json
+{
+  "quarantined": [
+    {
+      "job": "E2E Tests",
+      "reason": "Playwright timing issue on slow runners — tracked in #42",
+      "quarantined_at": "2025-01-15T10:00:00Z",
+      "review_by": "2025-01-29"
+    }
+  ],
+  "graduated": []
+}
+```
+
+## Quarantine Script
+
+```bash
+# Detect flakiness by re-running a job 5 times
+TEST_CMD="npm run test:run -w web" \
+  ./scripts/quarantine-flaky-check.sh detect "Web Unit Tests" 5
+
+# Manually quarantine a known-flaky job
+./scripts/quarantine-flaky-check.sh add "E2E Tests" "Playwright timing issue — see #42"
+
+# List all quarantined jobs
+./scripts/quarantine-flaky-check.sh list
+
+# Print CI-friendly report (exits 1 if any quarantine is overdue)
+./scripts/quarantine-flaky-check.sh report
+
+# Graduate a fixed job out of quarantine
+./scripts/quarantine-flaky-check.sh remove "E2E Tests"
+```
+
+## Automated Workflow
+
+The `flaky-quarantine.yml` workflow runs every Monday at 06:00 UTC and:
+
+1. Runs `report` to list all quarantined jobs and flag overdue ones.
+2. Uploads the quarantine state as a workflow artifact (retained 90 days).
+3. Posts a `::warning::` annotation in the Actions UI if any quarantine is overdue.
+
+You can also trigger it manually from the Actions tab to run flaky detection on a specific job.
+
+## Quarantine Rules
+
+1. **Quarantine does not disable the check.** The job still runs in CI. Failures are annotated but do not block merge while the job is under investigation.
+2. **Every quarantine has a review date** (14 days from quarantine by default). The weekly workflow flags overdue entries.
+3. **Quarantines must be resolved.** Either fix the root cause and graduate the job, or open a tracking issue and extend the review date with a comment explaining why.
+4. **Required checks remain required.** Quarantine is a tracking mechanism, not a bypass. If a required check is flaky, the fix is to stabilize it — not to remove it from the required list.
+
+## Resolving a Flaky Check
+
+1. Identify the root cause (timing, test isolation, external dependency, resource contention).
+2. Apply the fix in a PR.
+3. Run the detection script to confirm stability: `TEST_CMD="..." ./scripts/quarantine-flaky-check.sh detect "<job>" 10`
+4. Graduate the job: `./scripts/quarantine-flaky-check.sh remove "<job>"`
+5. Commit the updated `.github/flaky-quarantine.json`.
+
+## Common Causes and Fixes
+
+| Cause | Fix |
+|-------|-----|
+| Timing / async race | Add explicit waits; avoid `setTimeout` in tests |
+| Shared test state | Isolate test data; use `beforeEach` cleanup |
+| External service dependency | Mock the service in unit/integration tests |
+| Port conflicts | Use dynamic port allocation |
+| Resource exhaustion on CI runner | Reduce parallelism; add retry logic |

--- a/scripts/backup-restore-drill.sh
+++ b/scripts/backup-restore-drill.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# DEVOPS-214: Backup and restore drill for operational data.
+#
+# Creates a timestamped backup of the SQLite database and verifies it can be
+# fully restored. Produces actionable output on failure.
+#
+# Usage:
+#   ./scripts/backup-restore-drill.sh [command] [options]
+#
+# Commands:
+#   backup   [--db <path>] [--out <dir>]   Create a backup
+#   restore  [--db <path>] <backup-file>   Restore from a backup file
+#   drill    [--db <path>] [--out <dir>]   Full backup → restore → verify cycle
+#   list     [--out <dir>]                 List available backups
+#   prune    [--out <dir>] [--keep <n>]    Remove old backups, keep N most recent
+#
+# Environment variables (override defaults):
+#   DB_PATH   Path to the SQLite database file  (default: apps/api/prisma/dev.db)
+#   BACKUP_DIR Directory for backup files        (default: .backups)
+#   KEEP_COUNT Number of backups to keep on prune (default: 10)
+
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+heading() { echo -e "${CYAN}══ $* ══${NC}"; }
+ok()      { echo -e "${GREEN}✓${NC} $*"; }
+fail()    { echo -e "${RED}✗${NC} $*"; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+DB_PATH="${DB_PATH:-$ROOT/apps/api/prisma/dev.db}"
+BACKUP_DIR="${BACKUP_DIR:-$ROOT/.backups}"
+KEEP_COUNT="${KEEP_COUNT:-10}"
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+COMMAND="${1:-drill}"
+shift || true
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --db)    DB_PATH="$2";    shift 2 ;;
+    --out)   BACKUP_DIR="$2"; shift 2 ;;
+    --keep)  KEEP_COUNT="$2"; shift 2 ;;
+    -*)      error "Unknown option: $1"; exit 1 ;;
+    *)       POSITIONAL="${1}"; shift ;;
+  esac
+done
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+timestamp()    { date -u +"%Y%m%dT%H%M%SZ"; }
+human_time()   { date -u +"%Y-%m-%d %H:%M:%S UTC"; }
+backup_name()  { echo "backup-$(timestamp).db"; }
+
+require_sqlite3() {
+  if ! command -v sqlite3 &>/dev/null; then
+    error "sqlite3 is required but not installed."
+    error "Install it with: apt-get install sqlite3  OR  brew install sqlite3"
+    exit 1
+  fi
+}
+
+check_db_exists() {
+  local db="$1"
+  if [[ ! -f "$db" ]]; then
+    error "Database not found: $db"
+    error "Run 'npx prisma db push' in apps/api/ to create it first."
+    exit 1
+  fi
+}
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+cmd_backup() {
+  require_sqlite3
+  check_db_exists "$DB_PATH"
+
+  mkdir -p "$BACKUP_DIR"
+  local out_file="$BACKUP_DIR/$(backup_name)"
+
+  info "Source:  $DB_PATH"
+  info "Backup:  $out_file"
+  info "Time:    $(human_time)"
+  echo ""
+
+  # Use SQLite's online backup API via .backup command — safe for live databases
+  sqlite3 "$DB_PATH" ".backup '$out_file'"
+
+  local src_size dest_size
+  src_size=$(stat -c%s "$DB_PATH" 2>/dev/null || stat -f%z "$DB_PATH")
+  dest_size=$(stat -c%s "$out_file" 2>/dev/null || stat -f%z "$out_file")
+
+  ok "Backup created: $out_file"
+  info "Size: source=${src_size}B  backup=${dest_size}B"
+
+  # Basic integrity check on the backup itself
+  if sqlite3 "$out_file" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    ok "Backup integrity check passed."
+  else
+    fail "Backup integrity check FAILED."
+    error "The backup file may be corrupt. Do not use it for restore."
+    exit 1
+  fi
+
+  echo "$out_file"
+}
+
+cmd_restore() {
+  local backup_file="${POSITIONAL:-}"
+
+  if [[ -z "$backup_file" ]]; then
+    error "Usage: $0 restore [--db <path>] <backup-file>"
+    exit 1
+  fi
+
+  require_sqlite3
+
+  if [[ ! -f "$backup_file" ]]; then
+    error "Backup file not found: $backup_file"
+    exit 1
+  fi
+
+  # Verify backup integrity before restoring
+  info "Verifying backup integrity: $backup_file"
+  if ! sqlite3 "$backup_file" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    fail "Backup integrity check FAILED — aborting restore."
+    exit 1
+  fi
+  ok "Backup integrity verified."
+
+  # Safety: keep a copy of the current database before overwriting
+  if [[ -f "$DB_PATH" ]]; then
+    local safety_copy="${DB_PATH}.pre-restore-$(timestamp)"
+    cp "$DB_PATH" "$safety_copy"
+    warn "Existing database saved to: $safety_copy"
+  fi
+
+  info "Restoring: $backup_file → $DB_PATH"
+  mkdir -p "$(dirname "$DB_PATH")"
+  cp "$backup_file" "$DB_PATH"
+
+  # Verify the restored database
+  if sqlite3 "$DB_PATH" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    ok "Restore complete. Database integrity verified."
+  else
+    fail "Restored database failed integrity check."
+    error "Reverting to pre-restore copy: $safety_copy"
+    cp "$safety_copy" "$DB_PATH"
+    exit 1
+  fi
+}
+
+cmd_drill() {
+  heading "Backup / Restore Drill"
+  echo ""
+  info "Started: $(human_time)"
+  echo ""
+
+  require_sqlite3
+
+  local errors=0
+
+  # ── Step 1: Verify source database ────────────────────────────────────────
+  heading "Step 1: Source database check"
+  if [[ ! -f "$DB_PATH" ]]; then
+    warn "Database not found at $DB_PATH — creating an empty one for drill purposes."
+    mkdir -p "$(dirname "$DB_PATH")"
+    sqlite3 "$DB_PATH" "PRAGMA journal_mode=WAL;"
+  fi
+
+  if sqlite3 "$DB_PATH" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    ok "Source database integrity check passed."
+  else
+    fail "Source database integrity check FAILED."
+    errors=$((errors + 1))
+  fi
+
+  # Record row counts for verification after restore
+  local workspace_count contract_count interaction_count audit_count share_count
+  workspace_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM workspaces;" 2>/dev/null || echo "0")
+  contract_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM saved_contracts;" 2>/dev/null || echo "0")
+  interaction_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM saved_interactions;" 2>/dev/null || echo "0")
+  audit_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM audit_logs;" 2>/dev/null || echo "0")
+  share_count=$(sqlite3 "$DB_PATH" "SELECT COUNT(*) FROM share_links;" 2>/dev/null || echo "0")
+
+  info "Row counts before backup:"
+  info "  workspaces:         $workspace_count"
+  info "  saved_contracts:    $contract_count"
+  info "  saved_interactions: $interaction_count"
+  info "  audit_logs:         $audit_count"
+  info "  share_links:        $share_count"
+  echo ""
+
+  # ── Step 2: Create backup ──────────────────────────────────────────────────
+  heading "Step 2: Create backup"
+  mkdir -p "$BACKUP_DIR"
+  local backup_file="$BACKUP_DIR/drill-$(timestamp).db"
+
+  sqlite3 "$DB_PATH" ".backup '$backup_file'"
+
+  if [[ -f "$backup_file" ]]; then
+    ok "Backup created: $backup_file"
+  else
+    fail "Backup file was not created."
+    errors=$((errors + 1))
+  fi
+
+  if sqlite3 "$backup_file" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    ok "Backup integrity check passed."
+  else
+    fail "Backup integrity check FAILED."
+    errors=$((errors + 1))
+  fi
+  echo ""
+
+  # ── Step 3: Restore to a temp location ────────────────────────────────────
+  heading "Step 3: Restore to temporary location"
+  local restore_target="/tmp/drill-restore-$(timestamp).db"
+  cp "$backup_file" "$restore_target"
+
+  if sqlite3 "$restore_target" "PRAGMA integrity_check;" | grep -q "^ok$"; then
+    ok "Restored database integrity check passed."
+  else
+    fail "Restored database integrity check FAILED."
+    errors=$((errors + 1))
+  fi
+  echo ""
+
+  # ── Step 4: Verify row counts match ───────────────────────────────────────
+  heading "Step 4: Verify row counts"
+  local restored_workspaces restored_contracts restored_interactions restored_audit restored_shares
+  restored_workspaces=$(sqlite3 "$restore_target" "SELECT COUNT(*) FROM workspaces;" 2>/dev/null || echo "-1")
+  restored_contracts=$(sqlite3 "$restore_target" "SELECT COUNT(*) FROM saved_contracts;" 2>/dev/null || echo "-1")
+  restored_interactions=$(sqlite3 "$restore_target" "SELECT COUNT(*) FROM saved_interactions;" 2>/dev/null || echo "-1")
+  restored_audit=$(sqlite3 "$restore_target" "SELECT COUNT(*) FROM audit_logs;" 2>/dev/null || echo "-1")
+  restored_shares=$(sqlite3 "$restore_target" "SELECT COUNT(*) FROM share_links;" 2>/dev/null || echo "-1")
+
+  check_count() {
+    local table="$1" expected="$2" actual="$3"
+    if [[ "$expected" == "$actual" ]]; then
+      ok "$table: $actual rows (matches)"
+    else
+      fail "$table: expected $expected rows, got $actual"
+      errors=$((errors + 1))
+    fi
+  }
+
+  check_count "workspaces"         "$workspace_count"    "$restored_workspaces"
+  check_count "saved_contracts"    "$contract_count"     "$restored_contracts"
+  check_count "saved_interactions" "$interaction_count"  "$restored_interactions"
+  check_count "audit_logs"         "$audit_count"        "$restored_audit"
+  check_count "share_links"        "$share_count"        "$restored_shares"
+  echo ""
+
+  # ── Cleanup temp restore ───────────────────────────────────────────────────
+  rm -f "$restore_target"
+
+  # ── Summary ───────────────────────────────────────────────────────────────
+  heading "Drill Summary"
+  info "Completed: $(human_time)"
+  info "Backup:    $backup_file"
+  echo ""
+
+  if [[ $errors -eq 0 ]]; then
+    ok "All drill checks passed. Backup is restorable."
+    exit 0
+  else
+    fail "$errors drill check(s) FAILED."
+    error "The backup may not be reliable. Investigate before relying on it."
+    exit 1
+  fi
+}
+
+cmd_list() {
+  if [[ ! -d "$BACKUP_DIR" ]]; then
+    info "No backup directory found at: $BACKUP_DIR"
+    return
+  fi
+
+  heading "Available backups in $BACKUP_DIR"
+  echo ""
+  local count=0
+  while IFS= read -r -d '' f; do
+    local size
+    size=$(stat -c%s "$f" 2>/dev/null || stat -f%z "$f")
+    printf "  %-50s  %s bytes\n" "$(basename "$f")" "$size"
+    count=$((count + 1))
+  done < <(find "$BACKUP_DIR" -maxdepth 1 -name "*.db" -print0 | sort -z)
+
+  echo ""
+  info "Total: $count backup(s)"
+}
+
+cmd_prune() {
+  if [[ ! -d "$BACKUP_DIR" ]]; then
+    info "No backup directory found — nothing to prune."
+    return
+  fi
+
+  heading "Pruning backups (keeping $KEEP_COUNT most recent)"
+  echo ""
+
+  local all_backups=()
+  while IFS= read -r -d '' f; do
+    all_backups+=("$f")
+  done < <(find "$BACKUP_DIR" -maxdepth 1 -name "*.db" -print0 | sort -rz)
+
+  local total=${#all_backups[@]}
+  if [[ $total -le $KEEP_COUNT ]]; then
+    info "Only $total backup(s) found — nothing to prune."
+    return
+  fi
+
+  local to_delete=$(( total - KEEP_COUNT ))
+  info "Removing $to_delete old backup(s)..."
+
+  for (( i=KEEP_COUNT; i<total; i++ )); do
+    rm -f "${all_backups[$i]}"
+    info "  Removed: $(basename "${all_backups[$i]}")"
+  done
+
+  ok "Pruning complete. $KEEP_COUNT backup(s) retained."
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+case "$COMMAND" in
+  backup)  cmd_backup  ;;
+  restore) cmd_restore ;;
+  drill)   cmd_drill   ;;
+  list)    cmd_list    ;;
+  prune)   cmd_prune   ;;
+  *)
+    echo "Usage: $0 <backup|restore|drill|list|prune> [options]"
+    echo ""
+    echo "Commands:"
+    echo "  backup   [--db <path>] [--out <dir>]   Create a backup"
+    echo "  restore  [--db <path>] <backup-file>   Restore from a backup"
+    echo "  drill    [--db <path>] [--out <dir>]   Full backup→restore→verify cycle"
+    echo "  list     [--out <dir>]                 List available backups"
+    echo "  prune    [--out <dir>] [--keep <n>]    Remove old backups"
+    echo ""
+    echo "Environment variables:"
+    echo "  DB_PATH     Path to SQLite database (default: apps/api/prisma/dev.db)"
+    echo "  BACKUP_DIR  Backup output directory  (default: .backups)"
+    echo "  KEEP_COUNT  Backups to keep on prune (default: 10)"
+    exit 1
+    ;;
+esac

--- a/scripts/promote-env.sh
+++ b/scripts/promote-env.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# DEVOPS-209: Configuration promotion helper.
+# Copies non-secret env vars from one profile's .env.example to a target .env file.
+#
+# Usage:
+#   ./scripts/promote-env.sh <source-profile> <target-profile> [--app api|web] [--dry-run]
+#
+# Profiles: local | demo | ci
+# The script never copies variables whose names contain KEY, SECRET, or TOKEN.
+
+set -euo pipefail
+
+# ── Colour helpers ────────────────────────────────────────────────────────────
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+info()  { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+SOURCE_PROFILE="${1:-}"
+TARGET_PROFILE="${2:-}"
+APP_FILTER=""
+DRY_RUN=false
+
+shift 2 2>/dev/null || true
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) APP_FILTER="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    *) error "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "$SOURCE_PROFILE" || -z "$TARGET_PROFILE" ]]; then
+  echo "Usage: $0 <source-profile> <target-profile> [--app api|web] [--dry-run]"
+  echo "Profiles: local | demo | ci"
+  exit 1
+fi
+
+VALID_PROFILES=("local" "demo" "ci")
+for p in "$SOURCE_PROFILE" "$TARGET_PROFILE"; do
+  if [[ ! " ${VALID_PROFILES[*]} " =~ " $p " ]]; then
+    error "Unknown profile '$p'. Valid profiles: ${VALID_PROFILES[*]}"
+    exit 1
+  fi
+done
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# ── Profile → env file mappings ───────────────────────────────────────────────
+# Source is always the .env.example (template); target is the live .env file.
+declare -A API_TARGET=( [local]="apps/api/.env" [demo]="apps/api/.env.demo" [ci]="apps/api/.env.ci" )
+declare -A WEB_TARGET=( [local]="apps/web/.env.local" [demo]="apps/web/.env.demo" [ci]="apps/web/.env.ci" )
+
+API_EXAMPLE="apps/api/.env.example"
+WEB_EXAMPLE="apps/web/.env.example"
+
+# ── Promotion logic ───────────────────────────────────────────────────────────
+promote_app() {
+  local app="$1"          # api | web
+  local example_rel="$2"  # relative path to .env.example
+  local target_rel="$3"   # relative path to target .env file
+
+  local example="$ROOT/$example_rel"
+  local target="$ROOT/$target_rel"
+
+  if [[ ! -f "$example" ]]; then
+    warn "Example file not found: $example_rel — skipping $app"
+    return
+  fi
+
+  info "Promoting $app: $example_rel → $target_rel"
+
+  local promoted=0
+  local skipped=0
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # Pass through comments and blank lines unchanged
+    if [[ "$line" =~ ^[[:space:]]*# || -z "$line" ]]; then
+      $DRY_RUN || echo "$line" >> "$target"
+      continue
+    fi
+
+    # Extract variable name
+    var_name="${line%%=*}"
+
+    # Skip secrets
+    if [[ "$var_name" =~ (KEY|SECRET|TOKEN) ]]; then
+      warn "  Skipping secret: $var_name"
+      skipped=$((skipped + 1))
+      continue
+    fi
+
+    if $DRY_RUN; then
+      echo "  [would set] $line"
+    else
+      echo "$line" >> "$target"
+    fi
+    promoted=$((promoted + 1))
+  done < "$example"
+
+  info "  Promoted: $promoted vars, skipped (secrets): $skipped"
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+$DRY_RUN && warn "DRY RUN — no files will be written."
+info "Promoting config: $SOURCE_PROFILE → $TARGET_PROFILE"
+echo ""
+
+if [[ -z "$APP_FILTER" || "$APP_FILTER" == "api" ]]; then
+  target_file="${API_TARGET[$TARGET_PROFILE]}"
+  if ! $DRY_RUN; then
+    mkdir -p "$(dirname "$ROOT/$target_file")"
+    # Write header
+    cat > "$ROOT/$target_file" <<EOF
+# Promoted from $SOURCE_PROFILE → $TARGET_PROFILE by scripts/promote-env.sh
+# Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# RUNTIME_MODE=$TARGET_PROFILE
+
+EOF
+  fi
+  promote_app "api" "$API_EXAMPLE" "$target_file"
+fi
+
+echo ""
+
+if [[ -z "$APP_FILTER" || "$APP_FILTER" == "web" ]]; then
+  target_file="${WEB_TARGET[$TARGET_PROFILE]}"
+  if ! $DRY_RUN; then
+    mkdir -p "$(dirname "$ROOT/$target_file")"
+    cat > "$ROOT/$target_file" <<EOF
+# Promoted from $SOURCE_PROFILE → $TARGET_PROFILE by scripts/promote-env.sh
+# Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+# RUNTIME_MODE=$TARGET_PROFILE
+
+EOF
+  fi
+  promote_app "web" "$WEB_EXAMPLE" "$target_file"
+fi
+
+echo ""
+if $DRY_RUN; then
+  info "Dry run complete. Re-run without --dry-run to apply."
+else
+  info "Promotion complete. Review the generated files and fill in any secrets manually."
+  info "Then run: npm run check-drift"
+fi

--- a/scripts/quarantine-flaky-check.sh
+++ b/scripts/quarantine-flaky-check.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# DEVOPS-213: Flaky-check quarantine helper.
+#
+# Detects, records, and reports flaky CI jobs without removing required protections.
+#
+# Usage:
+#   ./scripts/quarantine-flaky-check.sh <command> [options]
+#
+# Commands:
+#   detect  <job-name> <run-count>   Re-run a job N times and flag if it fails intermittently
+#   add     <job-name> <reason>      Manually quarantine a known-flaky job
+#   remove  <job-name>               Graduate a job out of quarantine
+#   list                             List all currently quarantined jobs
+#   report                           Print a summary report (used by CI)
+#
+# Quarantine state is stored in .github/flaky-quarantine.json
+
+set -euo pipefail
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; CYAN='\033[0;36m'; NC='\033[0m'
+info()    { echo -e "${GREEN}[INFO]${NC}  $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC}  $*"; }
+error()   { echo -e "${RED}[ERROR]${NC} $*" >&2; }
+heading() { echo -e "${CYAN}$*${NC}"; }
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+QUARANTINE_FILE="$ROOT/.github/flaky-quarantine.json"
+
+# ── Ensure quarantine file exists ─────────────────────────────────────────────
+init_file() {
+  if [[ ! -f "$QUARANTINE_FILE" ]]; then
+    echo '{"quarantined": [], "graduated": []}' > "$QUARANTINE_FILE"
+    info "Created $QUARANTINE_FILE"
+  fi
+}
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+timestamp() { date -u +"%Y-%m-%dT%H:%M:%SZ"; }
+
+is_quarantined() {
+  local job="$1"
+  python3 -c "
+import json, sys
+data = json.load(open('$QUARANTINE_FILE'))
+names = [e['job'] for e in data.get('quarantined', [])]
+sys.exit(0 if '$job' in names else 1)
+" 2>/dev/null
+}
+
+# ── Commands ──────────────────────────────────────────────────────────────────
+
+cmd_detect() {
+  local job_name="${1:-}"
+  local run_count="${2:-5}"
+
+  if [[ -z "$job_name" ]]; then
+    error "Usage: $0 detect <job-name> [run-count]"
+    exit 1
+  fi
+
+  heading "Flaky detection: $job_name (${run_count} runs)"
+  echo ""
+
+  local pass=0 fail=0
+
+  for i in $(seq 1 "$run_count"); do
+    echo -n "  Run $i/$run_count ... "
+    # In CI this would invoke the actual test command passed via env var TEST_CMD.
+    # Here we simulate by checking if TEST_CMD is set and running it.
+    if [[ -n "${TEST_CMD:-}" ]]; then
+      if eval "$TEST_CMD" > /tmp/flaky-run-"$i".log 2>&1; then
+        echo -e "${GREEN}PASS${NC}"
+        pass=$((pass + 1))
+      else
+        echo -e "${RED}FAIL${NC}"
+        fail=$((fail + 1))
+      fi
+    else
+      warn "TEST_CMD not set — skipping actual execution (dry detection mode)"
+      break
+    fi
+  done
+
+  echo ""
+  info "Results: $pass passed, $fail failed out of $run_count runs"
+
+  if [[ $fail -gt 0 && $pass -gt 0 ]]; then
+    warn "Job '$job_name' is FLAKY ($fail/$run_count failures)"
+    cmd_add "$job_name" "auto-detected: $fail/$run_count failures on $(timestamp)"
+    exit 2  # non-zero but distinct from hard failure
+  elif [[ $fail -eq "$run_count" ]]; then
+    error "Job '$job_name' CONSISTENTLY FAILS — this is not flakiness, fix the job."
+    exit 1
+  else
+    info "Job '$job_name' appears stable."
+  fi
+}
+
+cmd_add() {
+  local job_name="${1:-}"
+  local reason="${2:-manually quarantined}"
+
+  if [[ -z "$job_name" ]]; then
+    error "Usage: $0 add <job-name> <reason>"
+    exit 1
+  fi
+
+  init_file
+
+  if is_quarantined "$job_name"; then
+    warn "'$job_name' is already quarantined."
+    return
+  fi
+
+  python3 - <<PYEOF
+import json
+data = json.load(open('$QUARANTINE_FILE'))
+data['quarantined'].append({
+    'job': '$job_name',
+    'reason': '$reason',
+    'quarantined_at': '$(timestamp)',
+    'review_by': '$(date -u -d "+14 days" +"%Y-%m-%d" 2>/dev/null || date -u -v+14d +"%Y-%m-%d" 2>/dev/null || echo "review-needed")'
+})
+json.dump(data, open('$QUARANTINE_FILE', 'w'), indent=2)
+PYEOF
+
+  warn "Quarantined: $job_name — $reason"
+  warn "This job will still run in CI but failures will be annotated, not blocking."
+  warn "Review by: $(python3 -c "import json; q=[e for e in json.load(open('$QUARANTINE_FILE'))['quarantined'] if e['job']=='$job_name']; print(q[-1]['review_by'] if q else 'unknown')")"
+}
+
+cmd_remove() {
+  local job_name="${1:-}"
+
+  if [[ -z "$job_name" ]]; then
+    error "Usage: $0 remove <job-name>"
+    exit 1
+  fi
+
+  init_file
+
+  if ! is_quarantined "$job_name"; then
+    warn "'$job_name' is not currently quarantined."
+    return
+  fi
+
+  python3 - <<PYEOF
+import json
+data = json.load(open('$QUARANTINE_FILE'))
+entry = next((e for e in data['quarantined'] if e['job'] == '$job_name'), None)
+if entry:
+    data['quarantined'] = [e for e in data['quarantined'] if e['job'] != '$job_name']
+    entry['graduated_at'] = '$(timestamp)'
+    data['graduated'].append(entry)
+json.dump(data, open('$QUARANTINE_FILE', 'w'), indent=2)
+PYEOF
+
+  info "Graduated '$job_name' out of quarantine."
+}
+
+cmd_list() {
+  init_file
+  heading "Currently quarantined jobs:"
+  echo ""
+  python3 - <<PYEOF
+import json
+data = json.load(open('$QUARANTINE_FILE'))
+items = data.get('quarantined', [])
+if not items:
+    print('  (none)')
+else:
+    for e in items:
+        print(f"  • {e['job']}")
+        print(f"    Reason:      {e['reason']}")
+        print(f"    Since:       {e['quarantined_at']}")
+        print(f"    Review by:   {e['review_by']}")
+        print()
+PYEOF
+}
+
+cmd_report() {
+  init_file
+  python3 - <<PYEOF
+import json, sys
+data = json.load(open('$QUARANTINE_FILE'))
+items = data.get('quarantined', [])
+if not items:
+    print('✅ No quarantined checks.')
+    sys.exit(0)
+
+print(f'⚠️  {len(items)} quarantined check(s):')
+for e in items:
+    print(f"  • {e['job']} (since {e['quarantined_at']}, review by {e['review_by']})")
+    print(f"    {e['reason']}")
+
+# Exit non-zero if any entry is past its review date
+from datetime import datetime, timezone
+today = datetime.now(timezone.utc).date()
+overdue = [e for e in items if e.get('review_by', '') < str(today)]
+if overdue:
+    print()
+    print(f'❌ {len(overdue)} quarantine(s) are OVERDUE for review:')
+    for e in overdue:
+        print(f"  • {e['job']} — review was due {e['review_by']}")
+    sys.exit(1)
+PYEOF
+}
+
+# ── Dispatch ──────────────────────────────────────────────────────────────────
+COMMAND="${1:-}"
+shift || true
+
+case "$COMMAND" in
+  detect) cmd_detect "$@" ;;
+  add)    cmd_add    "$@" ;;
+  remove) cmd_remove "$@" ;;
+  list)   cmd_list        ;;
+  report) cmd_report      ;;
+  *)
+    echo "Usage: $0 <detect|add|remove|list|report> [args]"
+    echo ""
+    echo "Commands:"
+    echo "  detect <job> [runs]   Re-run a job N times and auto-quarantine if flaky"
+    echo "  add    <job> <reason> Manually quarantine a job"
+    echo "  remove <job>          Graduate a job out of quarantine"
+    echo "  list                  List quarantined jobs"
+    echo "  report                Print CI-friendly summary (exits 1 if overdue)"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## Summary

Resolves four assigned DevOps issues in a single PR.

---

### DEVOPS-209 — Standardize configuration promotion across local, demo, and ci profiles
Closes #353

- **`scripts/promote-env.sh`** — copies non-secret env vars between profiles (local/demo/ci); skips any variable containing `KEY`, `SECRET`, or `TOKEN`; supports `--dry-run` and `--app api|web` filters
- **`docs/config-promotion.md`** — full promotion workflow, profile differences, and instructions for adding new env vars
- **`apps/api/.env.example`** — uncommented and documented `RUNTIME_MODE`

---

### DEVOPS-211 — Document branch protection, required checks, and release discipline
Closes #355

- **`docs/branch-protection.md`** — authoritative reference: protected branches, required CI jobs per path filter, review requirements, merge strategy, versioning, release process, hotfix workflow
- **`CONTRIBUTING.md`** — replaced the outdated "direct pushes may be blocked" note with a proper branch protection table and PR process section

---

### DEVOPS-213 — Track flaky checks and quarantine unstable automation safely
Closes #357

- **`scripts/quarantine-flaky-check.sh`** — `detect` / `add` / `remove` / `list` / `report` commands; quarantine state stored in `.github/flaky-quarantine.json`; `report` exits 1 if any entry is past its review date
- **`.github/workflows/flaky-quarantine.yml`** — weekly Monday report + manual detection trigger; commits updated state back to the branch
- **`.github/flaky-quarantine.json`** — initial empty state file
- **`docs/flaky-check-quarantine.md`** — process, rules, and common causes/fixes

---

### DEVOPS-214 — Automate backup and restore drills for operational data
Closes #358

- **`scripts/backup-restore-drill.sh`** — `backup` / `restore` / `drill` / `list` / `prune` commands; uses SQLite's online backup API; verifies integrity and row-count parity across all five operational tables; reverts automatically on restore failure
- **`.github/workflows/backup-restore-drill.yml`** — weekly Sunday drill; seeds a fresh DB, runs the full cycle, uploads backup artifact (30-day retention)
- **`docs/backup-restore-drill.md`** — usage, what the drill verifies, failure response
- **`.gitignore`** — added `.backups/`

---

## Testing

- `scripts/promote-env.sh local demo --dry-run` — verified dry-run output
- `scripts/quarantine-flaky-check.sh list` — verified empty state
- `scripts/quarantine-flaky-check.sh report` — exits 0 with no quarantined jobs
- `scripts/backup-restore-drill.sh` — script syntax verified; full drill requires a seeded DB (covered by CI workflow)