### PR TITLE
ci(devops): promote drift and integrity checks to required CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.devops == 'true' || github.event_name == 'push'
     runs-on: ubuntu-latest
+    continue-on-error: false
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -256,7 +257,39 @@ jobs:
         run: npm ci
 
       - name: Check runtime drift
+        id: drift
         run: npm run check-drift
 
       - name: Check dependency integrity
+        id: integrity
         run: npm run check-integrity
+
+      - name: Write job summary
+        if: always()
+        run: |
+          echo "## DevOps Gate Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ steps.drift.outcome }}" = "success" ]; then
+            echo "✅ **Runtime drift check**: passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Runtime drift check**: failed — ports/URLs in docs or .env.example are out of sync with \`packages/api-contracts/src/runtime-defaults.ts\`. Run \`npm run check-drift\` locally to see details." >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ steps.integrity.outcome }}" = "success" ]; then
+            echo "✅ **Dependency integrity check**: passed" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "❌ **Dependency integrity check**: failed — lockfile or workspace dependency versions are inconsistent. Run \`npm run check-integrity\` locally to see details." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  required-checks:
+    name: Required Checks
+    needs: [devops]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Assert devops gate passed
+        run: |
+          if [ "${{ needs.devops.result }}" != "success" ] && [ "${{ needs.devops.result }}" != "skipped" ]; then
+            echo "❌ DevOps gate failed. Drift or integrity checks must pass before merge."
+            exit 1
+          fi
+          echo "✅ All required checks passed."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -150,6 +150,35 @@ soroban-dev-console/
 - `/src/auth` - Authentication guards
 - `/prisma` - Database schema, migrations, and seeds
 
+## CI Gates
+
+Every pull request must pass the **Required Checks** gate before it can be merged. This gate depends on the **DevOps** job, which runs two mandatory checks:
+
+### Runtime Drift Check (`npm run check-drift`)
+
+Verifies that all documented ports and URLs (in `README.md`, `docs/architecture.md`, `apps/api/.env.example`, and `apps/web/.env.example`) match the canonical values in `packages/api-contracts/src/runtime-defaults.ts`.
+
+**If it fails**: run `npm run check-drift` locally. The output will identify exactly which file and value is out of sync. Update the drifted file to match `runtime-defaults.ts` (or update `runtime-defaults.ts` if the canonical value itself changed).
+
+### Dependency Integrity Check (`npm run check-integrity`)
+
+Verifies that:
+1. `package-lock.json` is consistent with `package.json` (no lockfile drift).
+2. Workspace packages reference each other at consistent versions.
+3. Critical shared dependencies (`react`, `next`, `@stellar/stellar-sdk`, etc.) use the same version across all packages.
+
+**If it fails**: run `npm run check-integrity` locally. The output will identify the specific package and version mismatch. Common fixes:
+- Run `npm install` and commit the updated `package-lock.json`.
+- Align mismatched workspace dependency versions.
+
+### Job Summary
+
+When the DevOps job runs in CI, a step summary is written to the GitHub Actions run page with a plain-English pass/fail status and remediation hints for each check. No need to dig through raw logs.
+
+### Skipping the DevOps gate
+
+The DevOps job only runs when relevant files change (scripts, `runtime-defaults.ts`, docs, env examples, or lockfiles). If none of those files are touched, the job is skipped and the Required Checks gate treats a skip as a pass.
+
 ## Pull Request Process
 
 1. **Create a branch** from `main`:


### PR DESCRIPTION
## Summary

Closes #346

Promotes the existing `check-drift` and `check-integrity` scripts from informational CI steps into hard-blocking required gates.

## Changes

### `.github/workflows/ci.yml`
- Added `continue-on-error: false` to the `devops` job (makes failure semantics explicit)
- Added step IDs (`drift`, `integrity`) so the summary step can inspect outcomes
- Added an `if: always()` summary step that writes a plain-English pass/fail table to the GitHub Actions job summary, with remediation hints for each failure — no more digging through raw logs
- Added a new `required-checks` job that `needs: [devops]` and runs `if: always()`; it fails the workflow if `devops` failed, and passes if `devops` succeeded or was skipped (so unrelated PRs aren't blocked)

### `CONTRIBUTING.md`
- Added a **CI Gates** section documenting both checks, what triggers them, how to fix failures locally, and when the gate is skipped

## Testing

- Verified YAML is valid
- The `required-checks` job can be registered as a required status check in branch protection settings to enforce the gate on all PRs targeting `main`