### PR TITLE
feat: BE-205, BE-210, BE-212, BE-214 — Wave backend modules

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -108,3 +108,79 @@ model ShareLink {
   @@index([workspaceId, createdAt])
   @@map("share_links")
 }
+
+/// BE-205: Canonical verification state and eligibility record for a Wave contributor.
+model ContributorVerification {
+  id                   String   @id @default(cuid())
+  contributorId        String   @unique @map("contributor_id")
+  status               String   @default("pending")
+  manualReviewNote     String?  @map("manual_review_note")
+  priorCompletionCount Int      @default(0) @map("prior_completion_count")
+  restrictionReason    String?  @map("restriction_reason")
+  createdAt            DateTime @default(now()) @map("created_at")
+  updatedAt            DateTime @default(now()) @map("updated_at")
+
+  @@index([status])
+  @@map("contributor_verifications")
+}
+
+/// BE-210: Immutable audit record of a final appeal outcome.
+model AppealDecision {
+  id               String   @id @default(cuid())
+  appealId         String   @map("appeal_id")
+  contributorId    String   @map("contributor_id")
+  outcome          String
+  modelVersion     String?  @map("model_version")
+  humanOverride    Boolean  @default(false) @map("human_override")
+  rationaleSummary String?  @map("rationale_summary")
+  reviewedBy       String?  @map("reviewed_by")
+  decidedAt        DateTime @default(now()) @map("decided_at")
+
+  @@index([appealId])
+  @@index([contributorId])
+  @@index([decidedAt])
+  @@map("appeal_decisions")
+}
+
+/// BE-212: Delivery tracking record for a Wave operational notification event.
+model NotificationEvent {
+  id             String    @id @default(cuid())
+  recipientId    String    @map("recipient_id")
+  eventType      String    @map("event_type")
+  channel        String
+  payload        Json
+  deliveryStatus String    @default("pending") @map("delivery_status")
+  failureReason  String?   @map("failure_reason")
+  deliveredAt    DateTime? @map("delivered_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+
+  @@index([recipientId])
+  @@index([deliveryStatus])
+  @@index([eventType])
+  @@map("notification_events")
+}
+
+/// BE-214: Raw point-affecting event entry for ledger integrity verification.
+model PointLedgerEntry {
+  id            String   @id @default(cuid())
+  contributorId String   @map("contributor_id")
+  eventType     String   @map("event_type")
+  points        Int
+  referenceId   String?  @map("reference_id")
+  createdAt     DateTime @default(now()) @map("created_at")
+
+  @@index([contributorId])
+  @@index([eventType])
+  @@map("point_ledger_entries")
+}
+
+/// BE-214: Cached point total snapshot per contributor, repaired by the integrity verifier.
+model PointLedgerSnapshot {
+  id            String    @id @default(cuid())
+  contributorId String    @unique @map("contributor_id")
+  totalPoints   Int       @default(0) @map("total_points")
+  repairedAt    DateTime? @map("repaired_at")
+  updatedAt     DateTime  @default(now()) @map("updated_at")
+
+  @@map("point_ledger_snapshots")
+}

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,10 @@ import { RuntimeConfigModule } from "./modules/runtime-config/runtime-config.mod
 import { FixtureManifestModule } from "./modules/fixture-manifest/fixture-manifest.module.js";
 import { SharesModule } from "./modules/shares/shares.module.js";
 import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
+import { ContributorVerificationModule } from "./modules/contributor-verification/contributor-verification.module.js";
+import { AppealDecisionsModule } from "./modules/appeal-decisions/appeal-decisions.module.js";
+import { NotificationsModule } from "./modules/notifications/notifications.module.js";
+import { PointLedgerModule } from "./modules/point-ledger/point-ledger.module.js";
 
 @Module({
   imports: [
@@ -18,7 +22,11 @@ import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
     RuntimeConfigModule,
     FixtureManifestModule,
     SharesModule,
-    WorkspacesModule
+    WorkspacesModule,
+    ContributorVerificationModule,
+    AppealDecisionsModule,
+    NotificationsModule,
+    PointLedgerModule,
   ]
 })
 export class AppModule {}

--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.controller.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { AppealDecisionsService } from "./appeal-decisions.service.js";
+import type { RecordAppealDecisionDto } from "./appeal-decisions.service.js";
+
+@Controller("appeal-decisions")
+@UseGuards(OwnerKeyGuard)
+export class AppealDecisionsController {
+  constructor(private readonly service: AppealDecisionsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  record(@Body() dto: RecordAppealDecisionDto) {
+    return this.service.record(dto);
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.service.get(id);
+  }
+
+  @Get("by-appeal/:appealId")
+  listByAppeal(@Param("appealId") appealId: string) {
+    return this.service.listByAppeal(appealId);
+  }
+
+  @Get("by-contributor/:contributorId")
+  listByContributor(@Param("contributorId") contributorId: string) {
+    return this.service.listByContributor(contributorId);
+  }
+}

--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { AppealDecisionsController } from "./appeal-decisions.controller.js";
+import { AppealDecisionsService } from "./appeal-decisions.service.js";
+import { AppealDecisionsRepository } from "./appeal-decisions.repository.js";
+
+@Module({
+  controllers: [AppealDecisionsController],
+  providers: [AppealDecisionsService, AppealDecisionsRepository, PrismaService, AuditService],
+  exports: [AppealDecisionsService],
+})
+export class AppealDecisionsModule {}

--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.repository.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.repository.ts
@@ -1,0 +1,26 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+
+@Injectable()
+export class AppealDecisionsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findMany<T extends Prisma.AppealDecisionFindManyArgs>(
+    params: Prisma.SelectSubset<T, Prisma.AppealDecisionFindManyArgs>,
+  ) {
+    return this.prisma.appealDecision.findMany(params);
+  }
+
+  async findFirst<T extends Prisma.AppealDecisionFindFirstArgs>(
+    params: Prisma.SelectSubset<T, Prisma.AppealDecisionFindFirstArgs>,
+  ) {
+    return this.prisma.appealDecision.findFirst(params);
+  }
+
+  async create<T extends Prisma.AppealDecisionCreateArgs>(
+    params: Prisma.SelectSubset<T, Prisma.AppealDecisionCreateArgs>,
+  ) {
+    return this.prisma.appealDecision.create(params);
+  }
+}

--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.service.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { AppealDecisionsRepository } from "./appeal-decisions.repository.js";
+
+export type AppealOutcome = "approved" | "rejected" | "escalated";
+
+export interface RecordAppealDecisionDto {
+  appealId: string;
+  contributorId: string;
+  outcome: AppealOutcome;
+  modelVersion?: string;
+  humanOverride?: boolean;
+  rationaleSummary?: string;
+  reviewedBy?: string;
+}
+
+@Injectable()
+export class AppealDecisionsService {
+  constructor(
+    private readonly repository: AppealDecisionsRepository,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async record(dto: RecordAppealDecisionDto) {
+    const decision = await this.repository.create({
+      data: {
+        appealId: dto.appealId,
+        contributorId: dto.contributorId,
+        outcome: dto.outcome,
+        modelVersion: dto.modelVersion ?? null,
+        humanOverride: dto.humanOverride ?? false,
+        rationaleSummary: dto.rationaleSummary ?? null,
+        reviewedBy: dto.reviewedBy ?? null,
+      },
+    });
+    void this.audit.log({
+      actor: dto.reviewedBy ?? dto.contributorId,
+      action: "appeal.decision.recorded",
+      resourceType: "appeal_decision",
+      resourceId: decision.id,
+      summary: `Appeal ${dto.appealId} outcome: ${dto.outcome}`,
+      metadata: { humanOverride: dto.humanOverride, modelVersion: dto.modelVersion } as Prisma.InputJsonValue,
+    });
+    return decision;
+  }
+
+  @MapDbErrors()
+  async listByAppeal(appealId: string) {
+    return this.repository.findMany({
+      where: { appealId },
+      orderBy: { decidedAt: "desc" },
+    });
+  }
+
+  @MapDbErrors()
+  async listByContributor(contributorId: string) {
+    return this.repository.findMany({
+      where: { contributorId },
+      orderBy: { decidedAt: "desc" },
+    });
+  }
+
+  @MapDbErrors()
+  async get(id: string) {
+    const record = await this.repository.findFirst({ where: { id } });
+    if (!record) throw new NotFoundException("Appeal decision not found");
+    return record;
+  }
+}

--- a/apps/api/src/modules/contributor-verification/contributor-verification.controller.ts
+++ b/apps/api/src/modules/contributor-verification/contributor-verification.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Put,
+  UseGuards,
+} from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { ContributorVerificationService } from "./contributor-verification.service.js";
+import type { UpsertVerificationDto } from "./contributor-verification.service.js";
+
+@Controller("contributor-verifications")
+@UseGuards(OwnerKeyGuard)
+export class ContributorVerificationController {
+  constructor(private readonly service: ContributorVerificationService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+
+  @Get(":contributorId")
+  get(@Param("contributorId") contributorId: string) {
+    return this.service.get(contributorId);
+  }
+
+  @Get(":contributorId/eligibility")
+  eligibility(@Param("contributorId") contributorId: string) {
+    return this.service.isEligible(contributorId);
+  }
+
+  @Put(":contributorId")
+  @HttpCode(HttpStatus.OK)
+  upsert(@Param("contributorId") contributorId: string, @Body() dto: UpsertVerificationDto) {
+    return this.service.upsert({ ...dto, contributorId });
+  }
+}

--- a/apps/api/src/modules/contributor-verification/contributor-verification.module.ts
+++ b/apps/api/src/modules/contributor-verification/contributor-verification.module.ts
@@ -1,0 +1,13 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { ContributorVerificationController } from "./contributor-verification.controller.js";
+import { ContributorVerificationService } from "./contributor-verification.service.js";
+import { ContributorVerificationRepository } from "./contributor-verification.repository.js";
+
+@Module({
+  controllers: [ContributorVerificationController],
+  providers: [ContributorVerificationService, ContributorVerificationRepository, PrismaService, AuditService],
+  exports: [ContributorVerificationService],
+})
+export class ContributorVerificationModule {}

--- a/apps/api/src/modules/contributor-verification/contributor-verification.repository.ts
+++ b/apps/api/src/modules/contributor-verification/contributor-verification.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+
+@Injectable()
+export class ContributorVerificationRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findMany<T extends Prisma.ContributorVerificationFindManyArgs>(
+    params: Prisma.SelectSubset<T, Prisma.ContributorVerificationFindManyArgs>,
+  ) {
+    return this.prisma.contributorVerification.findMany(params);
+  }
+
+  async findFirst<T extends Prisma.ContributorVerificationFindFirstArgs>(
+    params: Prisma.SelectSubset<T, Prisma.ContributorVerificationFindFirstArgs>,
+  ) {
+    return this.prisma.contributorVerification.findFirst(params);
+  }
+
+  async upsert<T extends Prisma.ContributorVerificationUpsertArgs>(
+    params: Prisma.SelectSubset<T, Prisma.ContributorVerificationUpsertArgs>,
+  ) {
+    return this.prisma.contributorVerification.upsert(params);
+  }
+
+  async update<T extends Prisma.ContributorVerificationUpdateArgs>(
+    params: Prisma.SelectSubset<T, Prisma.ContributorVerificationUpdateArgs>,
+  ) {
+    return this.prisma.contributorVerification.update(params);
+  }
+}

--- a/apps/api/src/modules/contributor-verification/contributor-verification.service.ts
+++ b/apps/api/src/modules/contributor-verification/contributor-verification.service.ts
@@ -1,0 +1,73 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { ContributorVerificationRepository } from "./contributor-verification.repository.js";
+
+export type VerificationStatus = "pending" | "verified" | "restricted" | "rejected";
+
+export interface UpsertVerificationDto {
+  contributorId: string;
+  status: VerificationStatus;
+  manualReviewNote?: string;
+  priorCompletionCount?: number;
+  restrictionReason?: string;
+}
+
+@Injectable()
+export class ContributorVerificationService {
+  constructor(
+    private readonly repository: ContributorVerificationRepository,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async upsert(dto: UpsertVerificationDto) {
+    const record = await this.repository.upsert({
+      where: { contributorId: dto.contributorId },
+      create: {
+        contributorId: dto.contributorId,
+        status: dto.status,
+        manualReviewNote: dto.manualReviewNote ?? null,
+        priorCompletionCount: dto.priorCompletionCount ?? 0,
+        restrictionReason: dto.restrictionReason ?? null,
+      },
+      update: {
+        status: dto.status,
+        manualReviewNote: dto.manualReviewNote ?? null,
+        restrictionReason: dto.restrictionReason ?? null,
+        ...(dto.priorCompletionCount !== undefined
+          ? { priorCompletionCount: dto.priorCompletionCount }
+          : {}),
+        updatedAt: new Date(),
+      },
+    });
+    void this.audit.log({
+      actor: dto.contributorId,
+      action: "contributor.verification.upserted",
+      resourceType: "contributor_verification",
+      resourceId: record.id,
+      summary: `Verification status set to "${dto.status}"`,
+    });
+    return record;
+  }
+
+  @MapDbErrors()
+  async get(contributorId: string) {
+    const record = await this.repository.findFirst({ where: { contributorId } });
+    if (!record) throw new NotFoundException("Contributor verification record not found");
+    return record;
+  }
+
+  @MapDbErrors()
+  async list() {
+    return this.repository.findMany({ orderBy: { updatedAt: "desc" } });
+  }
+
+  @MapDbErrors()
+  async isEligible(contributorId: string): Promise<{ eligible: boolean; reason?: string }> {
+    const record = await this.repository.findFirst({ where: { contributorId } });
+    if (!record) return { eligible: false, reason: "No verification record found" };
+    if (record.status === "verified") return { eligible: true };
+    return { eligible: false, reason: record.restrictionReason ?? record.status };
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { NotificationsService } from "./notifications.service.js";
+import type { CreateNotificationDto, UpdateDeliveryStatusDto } from "./notifications.service.js";
+
+@Controller("notifications")
+@UseGuards(OwnerKeyGuard)
+export class NotificationsController {
+  constructor(private readonly service: NotificationsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateNotificationDto) {
+    return this.service.create(dto);
+  }
+
+  @Get("pending")
+  listPending() {
+    return this.service.listPending();
+  }
+
+  @Get("recipient/:recipientId")
+  listByRecipient(@Param("recipientId") recipientId: string) {
+    return this.service.listByRecipient(recipientId);
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.service.get(id);
+  }
+
+  @Patch(":id/delivery-status")
+  @HttpCode(HttpStatus.OK)
+  updateDeliveryStatus(@Param("id") id: string, @Body() dto: UpdateDeliveryStatusDto) {
+    return this.service.updateDeliveryStatus(id, dto);
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.module.ts
+++ b/apps/api/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { NotificationsController } from "./notifications.controller.js";
+import { NotificationsService } from "./notifications.service.js";
+import { NotificationsRepository } from "./notifications.repository.js";
+
+@Module({
+  controllers: [NotificationsController],
+  providers: [NotificationsService, NotificationsRepository, PrismaService],
+  exports: [NotificationsService],
+})
+export class NotificationsModule {}

--- a/apps/api/src/modules/notifications/notifications.repository.ts
+++ b/apps/api/src/modules/notifications/notifications.repository.ts
@@ -1,0 +1,32 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+
+@Injectable()
+export class NotificationsRepository {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async findMany<T extends Prisma.NotificationEventFindManyArgs>(
+    params: Prisma.SelectSubset<T, Prisma.NotificationEventFindManyArgs>,
+  ) {
+    return this.prisma.notificationEvent.findMany(params);
+  }
+
+  async findFirst<T extends Prisma.NotificationEventFindFirstArgs>(
+    params: Prisma.SelectSubset<T, Prisma.NotificationEventFindFirstArgs>,
+  ) {
+    return this.prisma.notificationEvent.findFirst(params);
+  }
+
+  async create<T extends Prisma.NotificationEventCreateArgs>(
+    params: Prisma.SelectSubset<T, Prisma.NotificationEventCreateArgs>,
+  ) {
+    return this.prisma.notificationEvent.create(params);
+  }
+
+  async update<T extends Prisma.NotificationEventUpdateArgs>(
+    params: Prisma.SelectSubset<T, Prisma.NotificationEventUpdateArgs>,
+  ) {
+    return this.prisma.notificationEvent.update(params);
+  }
+}

--- a/apps/api/src/modules/notifications/notifications.service.ts
+++ b/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,74 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+import { NotificationsRepository } from "./notifications.repository.js";
+
+export type NotificationChannel = "in_app" | "email" | "webhook";
+export type DeliveryStatus = "pending" | "delivered" | "failed";
+
+export interface CreateNotificationDto {
+  recipientId: string;
+  eventType: string;
+  channel: NotificationChannel;
+  payload: Record<string, unknown>;
+}
+
+export interface UpdateDeliveryStatusDto {
+  status: DeliveryStatus;
+  failureReason?: string;
+}
+
+@Injectable()
+export class NotificationsService {
+  constructor(private readonly repository: NotificationsRepository) {}
+
+  @MapDbErrors()
+  async create(dto: CreateNotificationDto) {
+    return this.repository.create({
+      data: {
+        recipientId: dto.recipientId,
+        eventType: dto.eventType,
+        channel: dto.channel,
+        payload: dto.payload as Prisma.InputJsonValue,
+        deliveryStatus: "pending",
+      },
+    });
+  }
+
+  @MapDbErrors()
+  async updateDeliveryStatus(id: string, dto: UpdateDeliveryStatusDto) {
+    const existing = await this.repository.findFirst({ where: { id } });
+    if (!existing) throw new NotFoundException("Notification event not found");
+    return this.repository.update({
+      where: { id },
+      data: {
+        deliveryStatus: dto.status,
+        failureReason: dto.failureReason ?? null,
+        deliveredAt: dto.status === "delivered" ? new Date() : null,
+      },
+    });
+  }
+
+  @MapDbErrors()
+  async listByRecipient(recipientId: string) {
+    return this.repository.findMany({
+      where: { recipientId },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  @MapDbErrors()
+  async listPending() {
+    return this.repository.findMany({
+      where: { deliveryStatus: "pending" },
+      orderBy: { createdAt: "asc" },
+    });
+  }
+
+  @MapDbErrors()
+  async get(id: string) {
+    const record = await this.repository.findFirst({ where: { id } });
+    if (!record) throw new NotFoundException("Notification event not found");
+    return record;
+  }
+}

--- a/apps/api/src/modules/point-ledger/point-ledger.controller.ts
+++ b/apps/api/src/modules/point-ledger/point-ledger.controller.ts
@@ -1,0 +1,41 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  UseGuards,
+} from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { PointLedgerService } from "./point-ledger.service.js";
+import type { LedgerEntry } from "./point-ledger.service.js";
+
+@Controller("point-ledger")
+@UseGuards(OwnerKeyGuard)
+export class PointLedgerController {
+  constructor(private readonly service: PointLedgerService) {}
+
+  @Post("entries")
+  @HttpCode(HttpStatus.CREATED)
+  addEntry(@Body() dto: LedgerEntry) {
+    return this.service.addEntry(dto);
+  }
+
+  @Get("balance/:contributorId")
+  getBalance(@Param("contributorId") contributorId: string) {
+    return this.service.getBalance(contributorId).then((total) => ({ contributorId, total }));
+  }
+
+  @Get("integrity")
+  verifyIntegrity() {
+    return this.service.verifyIntegrity();
+  }
+
+  @Post("repair")
+  @HttpCode(HttpStatus.OK)
+  repair() {
+    return this.service.repair();
+  }
+}

--- a/apps/api/src/modules/point-ledger/point-ledger.module.ts
+++ b/apps/api/src/modules/point-ledger/point-ledger.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { PointLedgerController } from "./point-ledger.controller.js";
+import { PointLedgerService } from "./point-ledger.service.js";
+
+@Module({
+  controllers: [PointLedgerController],
+  providers: [PointLedgerService, PrismaService, AuditService],
+  exports: [PointLedgerService],
+})
+export class PointLedgerModule {}

--- a/apps/api/src/modules/point-ledger/point-ledger.service.ts
+++ b/apps/api/src/modules/point-ledger/point-ledger.service.ts
@@ -1,0 +1,130 @@
+import { Injectable } from "@nestjs/common";
+import { Prisma } from "@prisma/client";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { PrismaService } from "../../lib/prisma.service.js";
+
+export interface LedgerEntry {
+  contributorId: string;
+  eventType: string;
+  points: number;
+  referenceId?: string;
+}
+
+export interface IntegrityReport {
+  checkedAt: string;
+  totalEntries: number;
+  mismatches: Array<{
+    contributorId: string;
+    expectedTotal: number;
+    recordedTotal: number;
+    delta: number;
+  }>;
+  ok: boolean;
+}
+
+@Injectable()
+export class PointLedgerService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async addEntry(entry: LedgerEntry): Promise<void> {
+    await this.prisma.pointLedgerEntry.create({
+      data: {
+        contributorId: entry.contributorId,
+        eventType: entry.eventType,
+        points: entry.points,
+        referenceId: entry.referenceId ?? null,
+      },
+    });
+  }
+
+  @MapDbErrors()
+  async getBalance(contributorId: string): Promise<number> {
+    const result = await this.prisma.pointLedgerEntry.aggregate({
+      where: { contributorId },
+      _sum: { points: true },
+    });
+    return result._sum.points ?? 0;
+  }
+
+  @MapDbErrors()
+  async verifyIntegrity(): Promise<IntegrityReport> {
+    const entries = await this.prisma.pointLedgerEntry.findMany({
+      select: { contributorId: true, points: true },
+    });
+
+    // Compute expected totals from raw entries
+    const expected = new Map<string, number>();
+    for (const e of entries) {
+      expected.set(e.contributorId, (expected.get(e.contributorId) ?? 0) + e.points);
+    }
+
+    // Compare against point_ledger_snapshots if any exist
+    const snapshots = await this.prisma.pointLedgerSnapshot.findMany({
+      select: { contributorId: true, totalPoints: true },
+    });
+
+    const mismatches: IntegrityReport["mismatches"] = [];
+    for (const snap of snapshots) {
+      const computed = expected.get(snap.contributorId) ?? 0;
+      if (computed !== snap.totalPoints) {
+        mismatches.push({
+          contributorId: snap.contributorId,
+          expectedTotal: computed,
+          recordedTotal: snap.totalPoints,
+          delta: computed - snap.totalPoints,
+        });
+      }
+    }
+
+    const report: IntegrityReport = {
+      checkedAt: new Date().toISOString(),
+      totalEntries: entries.length,
+      mismatches,
+      ok: mismatches.length === 0,
+    };
+
+    void this.audit.log({
+      actor: "system",
+      action: "point_ledger.integrity.verified",
+      resourceType: "point_ledger",
+      resourceId: "global",
+      summary: `Integrity check: ${mismatches.length} mismatch(es) found`,
+      metadata: report as unknown as Prisma.InputJsonValue,
+    });
+
+    return report;
+  }
+
+  @MapDbErrors()
+  async repair(): Promise<{ repairedCount: number }> {
+    const report = await this.verifyIntegrity();
+    let repairedCount = 0;
+
+    for (const mismatch of report.mismatches) {
+      await this.prisma.pointLedgerSnapshot.upsert({
+        where: { contributorId: mismatch.contributorId },
+        create: {
+          contributorId: mismatch.contributorId,
+          totalPoints: mismatch.expectedTotal,
+        },
+        update: { totalPoints: mismatch.expectedTotal, repairedAt: new Date() },
+      });
+      repairedCount++;
+    }
+
+    void this.audit.log({
+      actor: "system",
+      action: "point_ledger.integrity.repaired",
+      resourceType: "point_ledger",
+      resourceId: "global",
+      summary: `Repaired ${repairedCount} snapshot(s)`,
+    });
+
+    return { repairedCount };
+  }
+}

--- a/scripts/point-ledger-repair.ts
+++ b/scripts/point-ledger-repair.ts
@@ -1,0 +1,80 @@
+#!/usr/bin/env tsx
+/**
+ * BE-214: Point-ledger integrity verifier and repair utility.
+ *
+ * Usage:
+ *   npx tsx scripts/point-ledger-repair.ts [--dry-run]
+ *
+ * Recomputes expected point totals from raw ledger entries and repairs
+ * any snapshot mismatches. Pass --dry-run to report without writing.
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const prisma = new PrismaClient();
+const dryRun = process.argv.includes("--dry-run");
+
+async function main() {
+  console.log(`[point-ledger-repair] Starting integrity check (dry-run=${dryRun})`);
+
+  const entries = await prisma.pointLedgerEntry.findMany({
+    select: { contributorId: true, points: true },
+  });
+
+  const expected = new Map<string, number>();
+  for (const e of entries) {
+    expected.set(e.contributorId, (expected.get(e.contributorId) ?? 0) + e.points);
+  }
+
+  const snapshots = await prisma.pointLedgerSnapshot.findMany({
+    select: { contributorId: true, totalPoints: true },
+  });
+
+  const mismatches: Array<{ contributorId: string; expected: number; recorded: number }> = [];
+  for (const snap of snapshots) {
+    const computed = expected.get(snap.contributorId) ?? 0;
+    if (computed !== snap.totalPoints) {
+      mismatches.push({ contributorId: snap.contributorId, expected: computed, recorded: snap.totalPoints });
+    }
+  }
+
+  if (mismatches.length === 0) {
+    console.log("[point-ledger-repair] All snapshots are consistent. Nothing to repair.");
+    return;
+  }
+
+  console.log(`[point-ledger-repair] Found ${mismatches.length} mismatch(es):`);
+  for (const m of mismatches) {
+    console.log(`  contributor=${m.contributorId}  expected=${m.expected}  recorded=${m.recorded}  delta=${m.expected - m.recorded}`);
+  }
+
+  if (dryRun) {
+    console.log("[point-ledger-repair] Dry-run mode — no changes written.");
+    return;
+  }
+
+  for (const m of mismatches) {
+    await prisma.pointLedgerSnapshot.upsert({
+      where: { contributorId: m.contributorId },
+      create: { contributorId: m.contributorId, totalPoints: m.expected },
+      update: { totalPoints: m.expected, repairedAt: new Date() },
+    });
+  }
+
+  await prisma.auditLog.create({
+    data: {
+      actor: "system:repair-script",
+      action: "point_ledger.integrity.repaired",
+      resourceType: "point_ledger",
+      resourceId: "global",
+      summary: `Repaired ${mismatches.length} snapshot(s) via CLI script`,
+      metadata: { mismatches },
+    },
+  });
+
+  console.log(`[point-ledger-repair] Repaired ${mismatches.length} snapshot(s).`);
+}
+
+main()
+  .catch((err) => { console.error(err); process.exit(1); })
+  .finally(() => prisma.$disconnect());


### PR DESCRIPTION
## Summary

Implements four backend features for the Stellar Wave program.

### BE-205 — Contributor verification state and eligibility persistence (#332)
- `ContributorVerification` Prisma model: `status`, `manualReviewNote`, `priorCompletionCount`, `restrictionReason`
- Service with `upsert`, `get`, `list`, `isEligible` — audit-logged on every write
- Endpoints: `GET /contributor-verifications`, `PUT /:contributorId`, `GET /:contributorId/eligibility`

### BE-210 — Appeal decisions auditable ledger (#337)
- `AppealDecision` Prisma model: immutable records with `outcome`, `modelVersion`, `humanOverride`, `rationaleSummary`, `reviewedBy`
- Append-only service (no updates), full audit trail on every write
- Endpoints: `POST /appeal-decisions`, `GET /:id`, `GET /by-appeal/:appealId`, `GET /by-contributor/:contributorId`

### BE-212 — Notification delivery API for Wave operational events (#339)
- `NotificationEvent` Prisma model: `recipientId`, `eventType`, `channel`, `payload`, `deliveryStatus`, `deliveredAt`
- Service with `create`, `updateDeliveryStatus`, `listByRecipient`, `listPending`
- Endpoints: `POST /notifications`, `PATCH /:id/delivery-status`, `GET /pending`, `GET /recipient/:recipientId`

### BE-214 — Point-ledger integrity verifier and repair utility (#341)
- `PointLedgerEntry` + `PointLedgerSnapshot` Prisma models
- Service with `addEntry`, `getBalance`, `verifyIntegrity`, `repair` — all mismatches audit-logged
- Endpoints: `POST /point-ledger/entries`, `GET /balance/:contributorId`, `GET /integrity`, `POST /repair`
- `scripts/point-ledger-repair.ts` — standalone CLI with `--dry-run` support

## What was tested
- `tsc` build passes cleanly (`npm run build -w api`)
- `prisma generate` + `prisma db push` succeed with all 5 new models

Closes #332
Closes #337
Closes #339
Closes #341