### PR TITLE
feat: Wave 5 operational tracks (BE-215, BE-217, DEVOPS-205)

### DIFF
--- a/.github/ISSUE_TEMPLATE/wave5-abuse.md
+++ b/.github/ISSUE_TEMPLATE/wave5-abuse.md
@@ -1,0 +1,26 @@
+---
+name: Abuse / Policy Violation Report
+about: Report suspected abuse, gaming, or policy violations in Wave 5.
+title: '[ABUSE] '
+labels: abuse, wave5
+---
+
+## Track
+<!-- e.g., BE, FE, DEVOPS -->
+
+## Description
+Describe the suspected abuse or policy violation.
+
+## Affected Resource / Actor
+<!-- GitHub handle, workspace ID, or submission reference -->
+
+## Evidence
+<!-- Logs, screenshots, or links. Redact sensitive personal data. -->
+
+## Severity
+<!-- low | medium | high | critical -->
+
+## Acceptance Criteria
+- [ ] Report reviewed and triaged within 24 h
+- [ ] Appropriate action taken (warn / suspend / escalate)
+- [ ] Outcome documented and audit log updated

--- a/.github/ISSUE_TEMPLATE/wave5-ai-automation.md
+++ b/.github/ISSUE_TEMPLATE/wave5-ai-automation.md
@@ -1,0 +1,28 @@
+---
+name: AI / Automation Work
+about: Track AI-assisted features, automated workflows, or ML-related tasks.
+title: '[AI] '
+labels: ai-automation, wave5
+---
+
+## Track
+<!-- e.g., BE, FE, DEVOPS -->
+
+## Description
+Describe the AI feature or automation workflow being built or improved.
+
+## Inputs / Outputs
+**Inputs:** 
+**Expected Outputs:** 
+
+## Failure Modes
+<!-- What happens when the automation fails? How are errors surfaced? -->
+
+## Human Override
+<!-- Describe the manual fallback or override mechanism -->
+
+## Acceptance Criteria
+- [ ] Automation produces correct output on representative test cases
+- [ ] Failures produce actionable, structured error output
+- [ ] Human override path documented and tested
+- [ ] Change integrates cleanly with CI

--- a/.github/ISSUE_TEMPLATE/wave5-appeal.md
+++ b/.github/ISSUE_TEMPLATE/wave5-appeal.md
@@ -1,0 +1,26 @@
+---
+name: Appeal
+about: Submit a formal appeal against a decision, rejection, or penalty.
+title: '[APPEAL] '
+labels: appeal, wave5
+---
+
+## Track
+<!-- e.g., BE, FE, DEVOPS -->
+
+## Decision Being Appealed
+<!-- Describe the original decision, rejection, or penalty -->
+
+## Grounds for Appeal
+<!-- Why should this decision be reconsidered? -->
+
+## Supporting Evidence
+<!-- Links, screenshots, or references -->
+
+## Desired Outcome
+<!-- What resolution are you requesting? -->
+
+## Acceptance Criteria
+- [ ] Appeal reviewed by maintainer within 5 business days
+- [ ] Decision communicated to appellant
+- [ ] Outcome logged in audit trail

--- a/.github/ISSUE_TEMPLATE/wave5-fairness.md
+++ b/.github/ISSUE_TEMPLATE/wave5-fairness.md
@@ -1,0 +1,27 @@
+---
+name: Fairness / Points Dispute
+about: Report a fairness concern, incorrect point allocation, or scoring inconsistency.
+title: '[FAIRNESS] '
+labels: fairness, wave5
+---
+
+## Track
+<!-- e.g., BE, FE, DEVOPS -->
+
+## Description
+Describe the fairness concern or scoring inconsistency in detail.
+
+## Affected User / Resource
+<!-- GitHub handle, workspace ID, or ticket ID if applicable -->
+
+## Expected vs Actual
+**Expected:** 
+**Actual:** 
+
+## Evidence
+<!-- Screenshots, logs, or links that support the claim -->
+
+## Acceptance Criteria
+- [ ] Root cause identified and documented
+- [ ] Corrective action applied or escalated
+- [ ] Affected party notified of outcome

--- a/.github/ISSUE_TEMPLATE/wave5-infra.md
+++ b/.github/ISSUE_TEMPLATE/wave5-infra.md
@@ -1,0 +1,27 @@
+---
+name: Infrastructure / DevOps Task
+about: Track infrastructure changes, CI/CD work, or operational improvements.
+title: '[INFRA] '
+labels: infra, devops, wave5
+---
+
+## Track
+DEVOPS
+
+## Description
+Describe the infrastructure change or operational task.
+
+## Motivation
+Why is this change needed now?
+
+## Scope
+<!-- List affected services, pipelines, or configuration files -->
+
+## Rollback Plan
+<!-- How can this change be reverted if it causes issues? -->
+
+## Acceptance Criteria
+- [ ] Change deployed and verified in target environment
+- [ ] Runbook or documentation updated
+- [ ] Monitoring / alerting confirmed functional
+- [ ] No regressions in CI pipeline

--- a/.github/ISSUE_TEMPLATE/wave5-verification.md
+++ b/.github/ISSUE_TEMPLATE/wave5-verification.md
@@ -1,0 +1,27 @@
+---
+name: Verification Request / Bottleneck
+about: Track a stalled or failed verification step for a contributor or submission.
+title: '[VERIFICATION] '
+labels: verification, wave5
+---
+
+## Track
+<!-- e.g., BE, FE, DEVOPS -->
+
+## Description
+Describe the verification step that is blocked or failing.
+
+## Affected Submission / Contributor
+<!-- PR number, workspace ID, or GitHub handle -->
+
+## Blocking Since
+<!-- Date or approximate time the bottleneck started -->
+
+## Steps Already Taken
+1. 
+2. 
+
+## Acceptance Criteria
+- [ ] Verification completed or unblocked
+- [ ] Outcome recorded in audit log
+- [ ] Follow-up issue filed if systemic fix is needed

--- a/.github/wave5-labels.yml
+++ b/.github/wave5-labels.yml
@@ -1,0 +1,47 @@
+# Wave 5 operational-track labels
+# Apply with: gh label create --repo Ibinola/soroban-dev-console <name> --color <hex> --description <desc>
+# Or run: scripts/sync-labels.sh
+
+labels:
+  # ── Wave marker ────────────────────────────────────────────────────────────
+  - name: wave5
+    color: "5555ff"
+    description: "Issues belonging to the Wave 5 program"
+
+  # ── Operational tracks ─────────────────────────────────────────────────────
+  - name: fairness
+    color: "0075ca"
+    description: "Fairness concerns, points disputes, or scoring inconsistencies"
+
+  - name: verification
+    color: "e4e669"
+    description: "Stalled or failed verification steps"
+
+  - name: appeal
+    color: "d93f0b"
+    description: "Formal appeals against decisions or penalties"
+
+  - name: abuse
+    color: "b60205"
+    description: "Abuse reports and policy violation investigations"
+
+  - name: infra
+    color: "0e8a16"
+    description: "Infrastructure, CI/CD, and operational improvements"
+
+  - name: ai-automation
+    color: "6f42c1"
+    description: "AI-assisted features and automated workflows"
+
+  # ── Routing / triage helpers ───────────────────────────────────────────────
+  - name: needs-triage
+    color: "ededed"
+    description: "Newly filed; awaiting maintainer categorisation"
+
+  - name: escalated
+    color: "e11d48"
+    description: "Escalated to senior maintainer or external team"
+
+  - name: pending-response
+    color: "fef3c7"
+    description: "Waiting on reporter or external party for more information"

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -93,6 +93,29 @@ model AuditLog {
   @@map("audit_logs")
 }
 
+/// BE-215: Support ticket with category tagging and routing metadata for Wave 5 triage.
+model SupportTicket {
+  id          String   @id @default(cuid())
+  subject     String
+  body        String
+  category    String   /// verification | payout | appeal | bug | abuse
+  status      String   @default("open") /// open | in_progress | resolved | closed
+  priority    String   @default("normal") /// low | normal | high | urgent
+  reporterKey String   @map("reporter_key")
+  assigneeKey String?  @map("assignee_key")
+  tags        String   @default("[]") /// JSON-encoded string[]
+  metadata    Json?
+  resolvedAt  DateTime? @map("resolved_at")
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  @@index([category, status])
+  @@index([reporterKey])
+  @@index([status, priority])
+  @@index([createdAt])
+  @@map("support_tickets")
+}
+
 /// Immutable, read-only links that capture a point-in-time workspace snapshot.
 model ShareLink {
   id            String     @id @default(cuid())

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -6,6 +6,8 @@ import { RuntimeConfigModule } from "./modules/runtime-config/runtime-config.mod
 import { FixtureManifestModule } from "./modules/fixture-manifest/fixture-manifest.module.js";
 import { SharesModule } from "./modules/shares/shares.module.js";
 import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
+import { SupportTicketsModule } from "./modules/support-tickets/support-tickets.module.js";
+import { MaintainerDashboardModule } from "./modules/maintainer-dashboard/maintainer-dashboard.module.js";
 
 @Module({
   imports: [
@@ -18,7 +20,9 @@ import { WorkspacesModule } from "./modules/workspaces/workspaces.module.js";
     RuntimeConfigModule,
     FixtureManifestModule,
     SharesModule,
-    WorkspacesModule
+    WorkspacesModule,
+    SupportTicketsModule,
+    MaintainerDashboardModule,
   ]
 })
 export class AppModule {}

--- a/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.controller.ts
+++ b/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.controller.ts
@@ -1,0 +1,39 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { MaintainerDashboardService } from "./maintainer-dashboard.service.js";
+
+@Controller("maintainer-dashboard")
+@UseGuards(OwnerKeyGuard)
+export class MaintainerDashboardController {
+  constructor(private readonly service: MaintainerDashboardService) {}
+
+  /** GET /maintainer-dashboard — full dashboard summary */
+  @Get()
+  getSummary() {
+    return this.service.getSummary();
+  }
+
+  /** GET /maintainer-dashboard/triage-queue */
+  @Get("triage-queue")
+  getTriageQueue() {
+    return this.service.getTriageQueue();
+  }
+
+  /** GET /maintainer-dashboard/appeals */
+  @Get("appeals")
+  getAppealList() {
+    return this.service.getAppealList();
+  }
+
+  /** GET /maintainer-dashboard/verification-bottlenecks */
+  @Get("verification-bottlenecks")
+  getVerificationBottlenecks() {
+    return this.service.getVerificationBottlenecks();
+  }
+
+  /** GET /maintainer-dashboard/budget */
+  @Get("budget")
+  getBudgetView() {
+    return this.service.getBudgetView();
+  }
+}

--- a/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.module.ts
+++ b/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { MaintainerDashboardController } from "./maintainer-dashboard.controller.js";
+import { MaintainerDashboardService } from "./maintainer-dashboard.service.js";
+
+@Module({
+  controllers: [MaintainerDashboardController],
+  providers: [MaintainerDashboardService, PrismaService],
+  exports: [MaintainerDashboardService],
+})
+export class MaintainerDashboardModule {}

--- a/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.service.ts
+++ b/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.service.ts
@@ -1,0 +1,119 @@
+import { Injectable } from "@nestjs/common";
+import { IsOptional, IsString } from "class-validator";
+import { PrismaService } from "../../lib/prisma.service.js";
+
+export class DashboardQueryDto {
+  @IsOptional()
+  @IsString()
+  network?: string;
+}
+
+@Injectable()
+export class MaintainerDashboardService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Triage queue: open/in_progress tickets grouped by category and priority. */
+  async getTriageQueue() {
+    const tickets = await this.prisma.supportTicket.findMany({
+      where: { status: { in: ["open", "in_progress"] } },
+      select: {
+        id: true,
+        subject: true,
+        category: true,
+        priority: true,
+        status: true,
+        reporterKey: true,
+        assigneeKey: true,
+        createdAt: true,
+      },
+      orderBy: [{ priority: "desc" }, { createdAt: "asc" }],
+    });
+
+    const byCategory = tickets.reduce<Record<string, typeof tickets>>(
+      (acc, t) => {
+        (acc[t.category] ??= []).push(t);
+        return acc;
+      },
+      {},
+    );
+
+    return { total: tickets.length, byCategory };
+  }
+
+  /** Appeal list: tickets with category=appeal, any status. */
+  async getAppealList() {
+    const tickets = await this.prisma.supportTicket.findMany({
+      where: { category: "appeal" },
+      select: {
+        id: true,
+        subject: true,
+        status: true,
+        priority: true,
+        reporterKey: true,
+        assigneeKey: true,
+        createdAt: true,
+        resolvedAt: true,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+
+    return { total: tickets.length, tickets };
+  }
+
+  /** Verification bottlenecks: open verification tickets older than 48 h. */
+  async getVerificationBottlenecks() {
+    const cutoff = new Date(Date.now() - 48 * 60 * 60 * 1000);
+    const tickets = await this.prisma.supportTicket.findMany({
+      where: {
+        category: "verification",
+        status: { in: ["open", "in_progress"] },
+        createdAt: { lt: cutoff },
+      },
+      select: {
+        id: true,
+        subject: true,
+        status: true,
+        priority: true,
+        reporterKey: true,
+        assigneeKey: true,
+        createdAt: true,
+      },
+      orderBy: { createdAt: "asc" },
+    });
+
+    return { total: tickets.length, tickets };
+  }
+
+  /** Budget view: counts of tickets by status for capacity planning. */
+  async getBudgetView() {
+    const [open, inProgress, resolved, closed] = await Promise.all([
+      this.prisma.supportTicket.count({ where: { status: "open" } }),
+      this.prisma.supportTicket.count({ where: { status: "in_progress" } }),
+      this.prisma.supportTicket.count({ where: { status: "resolved" } }),
+      this.prisma.supportTicket.count({ where: { status: "closed" } }),
+    ]);
+
+    const byCategory = await this.prisma.supportTicket.groupBy({
+      by: ["category"],
+      _count: { id: true },
+    });
+
+    return {
+      statusCounts: { open, inProgress, resolved, closed },
+      byCategory: byCategory.map((r) => ({ category: r.category, count: r._count.id })),
+    };
+  }
+
+  /** Summary: combines all read-model views into a single dashboard payload. */
+  async getSummary() {
+    const [triageQueue, appealList, verificationBottlenecks, budgetView] =
+      await Promise.all([
+        this.getTriageQueue(),
+        this.getAppealList(),
+        this.getVerificationBottlenecks(),
+        this.getBudgetView(),
+      ]);
+
+    return { triageQueue, appealList, verificationBottlenecks, budgetView };
+  }
+}

--- a/apps/api/src/modules/support-tickets/support-tickets.controller.ts
+++ b/apps/api/src/modules/support-tickets/support-tickets.controller.ts
@@ -1,0 +1,50 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import {
+  CreateSupportTicketDto,
+  ListSupportTicketsDto,
+  SupportTicketsService,
+  UpdateSupportTicketDto,
+} from "./support-tickets.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("support-tickets")
+@UseGuards(OwnerKeyGuard)
+export class SupportTicketsController {
+  constructor(private readonly service: SupportTicketsService) {}
+
+  @Post()
+  @HttpCode(HttpStatus.CREATED)
+  create(@Body() dto: CreateSupportTicketDto, @Req() req: Request) {
+    return this.service.create((req as OwnerKeyRequest).ownerKey, dto);
+  }
+
+  @Get()
+  list(@Query() query: ListSupportTicketsDto) {
+    return this.service.list(query);
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.service.get(id);
+  }
+
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() dto: UpdateSupportTicketDto, @Req() req: Request) {
+    return this.service.update(id, (req as OwnerKeyRequest).ownerKey, dto);
+  }
+}

--- a/apps/api/src/modules/support-tickets/support-tickets.module.ts
+++ b/apps/api/src/modules/support-tickets/support-tickets.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { SupportTicketsController } from "./support-tickets.controller.js";
+import { SupportTicketsService } from "./support-tickets.service.js";
+
+@Module({
+  controllers: [SupportTicketsController],
+  providers: [SupportTicketsService, PrismaService, AuditService],
+  exports: [SupportTicketsService],
+})
+export class SupportTicketsModule {}

--- a/apps/api/src/modules/support-tickets/support-tickets.service.ts
+++ b/apps/api/src/modules/support-tickets/support-tickets.service.ts
@@ -1,0 +1,173 @@
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
+import { IsString, IsOptional, IsIn, IsInt, Min } from "class-validator";
+import { Type } from "class-transformer";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+import { AuditService } from "../../lib/audit.service.js";
+
+export const TICKET_CATEGORIES = ["verification", "payout", "appeal", "bug", "abuse"] as const;
+export const TICKET_STATUSES = ["open", "in_progress", "resolved", "closed"] as const;
+export const TICKET_PRIORITIES = ["low", "normal", "high", "urgent"] as const;
+
+export type TicketCategory = (typeof TICKET_CATEGORIES)[number];
+export type TicketStatus = (typeof TICKET_STATUSES)[number];
+export type TicketPriority = (typeof TICKET_PRIORITIES)[number];
+
+export class CreateSupportTicketDto {
+  @IsString()
+  subject!: string;
+
+  @IsString()
+  body!: string;
+
+  @IsIn(TICKET_CATEGORIES)
+  category!: TicketCategory;
+
+  @IsOptional()
+  @IsIn(TICKET_PRIORITIES)
+  priority?: TicketPriority;
+
+  @IsOptional()
+  tags?: string[];
+}
+
+export class UpdateSupportTicketDto {
+  @IsOptional()
+  @IsIn(TICKET_STATUSES)
+  status?: TicketStatus;
+
+  @IsOptional()
+  @IsIn(TICKET_PRIORITIES)
+  priority?: TicketPriority;
+
+  @IsOptional()
+  @IsString()
+  assigneeKey?: string;
+
+  @IsOptional()
+  tags?: string[];
+}
+
+export class ListSupportTicketsDto {
+  @IsOptional()
+  @IsIn(TICKET_CATEGORIES)
+  category?: TicketCategory;
+
+  @IsOptional()
+  @IsIn(TICKET_STATUSES)
+  status?: TicketStatus;
+
+  @IsOptional()
+  @IsIn(TICKET_PRIORITIES)
+  priority?: TicketPriority;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(0)
+  skip?: number;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  take?: number;
+}
+
+@Injectable()
+export class SupportTicketsService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async create(reporterKey: string, dto: CreateSupportTicketDto) {
+    if (!TICKET_CATEGORIES.includes(dto.category as TicketCategory)) {
+      throw new BadRequestException(`Invalid category. Must be one of: ${TICKET_CATEGORIES.join(", ")}`);
+    }
+
+    const ticket = await this.prisma.supportTicket.create({
+      data: {
+        subject: dto.subject.trim(),
+        body: dto.body.trim(),
+        category: dto.category,
+        priority: dto.priority ?? "normal",
+        reporterKey,
+        tags: JSON.stringify(dto.tags ?? []),
+      },
+    });
+
+    void this.audit.log({
+      actor: reporterKey,
+      action: "support_ticket.created",
+      resourceType: "support_ticket",
+      resourceId: ticket.id,
+      summary: `Created support ticket "${ticket.subject}" [${ticket.category}]`,
+    });
+
+    return { ...ticket, tags: JSON.parse(ticket.tags) };
+  }
+
+  @MapDbErrors()
+  async list(query: ListSupportTicketsDto = {}) {
+    const skip = query.skip ?? 0;
+    const take = query.take ?? 20;
+
+    const where = {
+      ...(query.category ? { category: query.category } : {}),
+      ...(query.status ? { status: query.status } : {}),
+      ...(query.priority ? { priority: query.priority } : {}),
+    };
+
+    const [rows, total] = await Promise.all([
+      this.prisma.supportTicket.findMany({
+        where,
+        orderBy: [{ priority: "desc" }, { createdAt: "desc" }],
+        skip,
+        take,
+      }),
+      this.prisma.supportTicket.count({ where }),
+    ]);
+
+    return {
+      data: rows.map((t) => ({ ...t, tags: JSON.parse(t.tags) })),
+      pagination: { total, skip, take },
+    };
+  }
+
+  @MapDbErrors()
+  async get(id: string) {
+    const ticket = await this.prisma.supportTicket.findUnique({ where: { id } });
+    if (!ticket) throw new NotFoundException("Support ticket not found");
+    return { ...ticket, tags: JSON.parse(ticket.tags) };
+  }
+
+  @MapDbErrors()
+  async update(id: string, actorKey: string, dto: UpdateSupportTicketDto) {
+    await this.get(id);
+
+    const ticket = await this.prisma.supportTicket.update({
+      where: { id },
+      data: {
+        ...(dto.status !== undefined ? { status: dto.status } : {}),
+        ...(dto.priority !== undefined ? { priority: dto.priority } : {}),
+        ...(dto.assigneeKey !== undefined ? { assigneeKey: dto.assigneeKey } : {}),
+        ...(dto.tags !== undefined ? { tags: JSON.stringify(dto.tags) } : {}),
+        ...(dto.status === "resolved" ? { resolvedAt: new Date() } : {}),
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "support_ticket.updated",
+      resourceType: "support_ticket",
+      resourceId: id,
+      summary: `Updated support ticket`,
+      metadata: { changes: dto as Record<string, unknown> } as Prisma.InputJsonValue,
+    });
+
+    return { ...ticket, tags: JSON.parse(ticket.tags) };
+  }
+}

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -168,6 +168,74 @@ export interface CreateSharePayload {
   expiresInSeconds?: number;
 }
 
+// ── Support Tickets (BE-215) ──────────────────────────────────────────────────
+
+export type TicketCategory = "verification" | "payout" | "appeal" | "bug" | "abuse";
+export type TicketStatus = "open" | "in_progress" | "resolved" | "closed";
+export type TicketPriority = "low" | "normal" | "high" | "urgent";
+
+export interface SupportTicketSummary {
+  id: string;
+  subject: string;
+  category: TicketCategory;
+  status: TicketStatus;
+  priority: TicketPriority;
+  reporterKey: string;
+  assigneeKey: string | null;
+  tags: string[];
+  createdAt: Date | string;
+  updatedAt: Date | string;
+}
+
+export interface CreateSupportTicketPayload {
+  subject: string;
+  body: string;
+  category: TicketCategory;
+  priority?: TicketPriority;
+  tags?: string[];
+}
+
+export interface UpdateSupportTicketPayload {
+  status?: TicketStatus;
+  priority?: TicketPriority;
+  assigneeKey?: string;
+  tags?: string[];
+}
+
+// ── Maintainer Dashboard (BE-217) ─────────────────────────────────────────────
+
+export interface TriageQueueView {
+  total: number;
+  byCategory: Record<string, SupportTicketSummary[]>;
+}
+
+export interface AppealListView {
+  total: number;
+  tickets: SupportTicketSummary[];
+}
+
+export interface VerificationBottlenecksView {
+  total: number;
+  tickets: SupportTicketSummary[];
+}
+
+export interface BudgetView {
+  statusCounts: {
+    open: number;
+    inProgress: number;
+    resolved: number;
+    closed: number;
+  };
+  byCategory: Array<{ category: TicketCategory; count: number }>;
+}
+
+export interface MaintainerDashboardSummary {
+  triageQueue: TriageQueueView;
+  appealList: AppealListView;
+  verificationBottlenecks: VerificationBottlenecksView;
+  budgetView: BudgetView;
+}
+
 // ── Transaction Status ─────────────────────────────────────────────────────────
 
 export type NormalizedTransactionStatus = "pending" | "success" | "failed";

--- a/scripts/sync-labels.sh
+++ b/scripts/sync-labels.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# DEVOPS-205: Sync Wave 5 labels to GitHub from .github/wave5-labels.yml
+# Usage: bash scripts/sync-labels.sh [--repo owner/repo]
+set -euo pipefail
+
+REPO="${REPO:-$(gh repo view --json nameWithOwner -q .nameWithOwner)}"
+LABELS_FILE="$(dirname "$0")/../.github/wave5-labels.yml"
+
+if ! command -v gh &>/dev/null; then
+  echo "ERROR: gh CLI not found. Install from https://cli.github.com" >&2
+  exit 1
+fi
+
+if ! command -v yq &>/dev/null; then
+  echo "ERROR: yq not found. Install from https://github.com/mikefarah/yq" >&2
+  exit 1
+fi
+
+echo "Syncing Wave 5 labels to ${REPO}..."
+
+yq e '.labels[]' -o=json "$LABELS_FILE" | while IFS= read -r label; do
+  name=$(echo "$label" | yq e '.name' -)
+  color=$(echo "$label" | yq e '.color' -)
+  description=$(echo "$label" | yq e '.description' -)
+
+  if gh label list --repo "$REPO" --json name -q '.[].name' | grep -qx "$name"; then
+    gh label edit "$name" --repo "$REPO" --color "$color" --description "$description" \
+      && echo "  updated: $name" \
+      || echo "  WARN: could not update $name"
+  else
+    gh label create "$name" --repo "$REPO" --color "$color" --description "$description" \
+      && echo "  created: $name" \
+      || echo "  WARN: could not create $name"
+  fi
+done
+
+echo "Done."


### PR DESCRIPTION
## Summary

Implements all three Wave 5 operational-track issues in a single cohesive change.

---

### BE-215 — Support-ticket tagging and routing metadata (closes #342)

- New `SupportTicket` Prisma model with `category` (verification / payout / appeal / bug / abuse), `priority`, `status`, `assigneeKey`, and `tags` fields.
- `support-tickets` NestJS module: typed `CreateSupportTicketDto` / `UpdateSupportTicketDto` / `ListSupportTicketsDto`, full CRUD endpoints (`POST /support-tickets`, `GET /support-tickets`, `GET /support-tickets/:id`, `PATCH /support-tickets/:id`), audit logging on create/update.
- Structured errors on invalid category; safe under retry (idempotent updates).

### BE-217 — Read-model endpoints for maintainer dashboards (closes #344)

- `maintainer-dashboard` NestJS module with five read-model endpoints:
  - `GET /maintainer-dashboard` — full summary (all views combined)
  - `GET /maintainer-dashboard/triage-queue` — open/in-progress tickets grouped by category
  - `GET /maintainer-dashboard/appeals` — all appeal tickets
  - `GET /maintainer-dashboard/verification-bottlenecks` — open verification tickets older than 48 h
  - `GET /maintainer-dashboard/budget` — status counts + per-category breakdown
- All endpoints protected by `OwnerKeyGuard`; parallel Prisma queries keep dashboards responsive.

### DEVOPS-205 — Wave 5 issue templates and labels (closes #349)

- Six new `.github/ISSUE_TEMPLATE/wave5-*.md` templates: fairness, verification, appeal, abuse, infra, ai-automation — each with structured fields and acceptance criteria.
- `.github/wave5-labels.yml` — declarative label definitions (wave5, fairness, verification, appeal, abuse, infra, ai-automation, needs-triage, escalated, pending-response).
- `scripts/sync-labels.sh` — idempotent script to create/update labels via `gh` CLI; fails loudly with actionable output on missing dependencies.

---

## What was tested

- `npm run build -w api` — passes (TypeScript clean)
- `npm run test -w api` — 1 suite, 1 pass, 0 fail
- Prisma client regenerated successfully against updated schema

## Notes

- `SupportTicket.tags` is stored as a JSON-encoded string (SQLite has no native array type); the service layer transparently serialises/deserialises.
- `scripts/sync-labels.sh` requires `gh` and `yq`; missing tools produce a clear error message.