### PR TITLE
feat(devops): add baseline observability dashboards and health check script

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,141 @@
+# Observability: Dashboards and Service-Level Signals
+
+> DEVOPS-207 — Baseline observability for Wave 5 operators.
+
+## Overview
+
+This document defines the baseline set of dashboards, metrics, and health signals for the Soroban DevConsole platform. It covers the API backend, web frontend, RPC proxy, and job queues so Wave 5 operators have a shared view of platform health.
+
+## Service-Level Signals
+
+### API Backend (`apps/api`, port 4000)
+
+| Signal | Source | Healthy Threshold |
+|--------|--------|-------------------|
+| HTTP 5xx rate | Access logs / NestJS interceptor | < 1% of requests over 5 min |
+| P95 response latency | Request timing middleware | < 500 ms |
+| Database query time | Prisma query events | < 200 ms P95 |
+| RPC proxy error rate | `apps/api/src/modules/rpc` | < 5% of proxied calls |
+| Active workspace count | `GET /health` endpoint | Informational |
+| Job queue depth | `apps/api/src/modules/jobs` | < 100 pending |
+| Audit log write failures | `apps/api/src/modules/point-ledger` | 0 per hour |
+
+### Web Frontend (`apps/web`, port 3000)
+
+| Signal | Source | Healthy Threshold |
+|--------|--------|-------------------|
+| SSR error rate | Next.js error boundary / logs | < 0.5% of page renders |
+| Core Web Vitals (LCP) | Browser RUM | < 2.5 s |
+| API fetch failure rate | Client-side fetch wrapper | < 2% of calls |
+| Build success | CI `web` job | 100% on `main` |
+
+### Soroban RPC Proxy
+
+| Signal | Source | Healthy Threshold |
+|--------|--------|-------------------|
+| Upstream RPC availability | `scripts/check-service-health.sh` | ≥ 1 endpoint reachable |
+| Cache hit rate | RPC module cache layer | > 40% |
+| Rate-limit rejections | RPC module | < 10/min per workspace |
+| Failover activations | RPC module logs | Alert on any activation |
+
+### Job Queues
+
+| Signal | Source | Healthy Threshold |
+|--------|--------|-------------------|
+| Queue depth | `apps/api/src/modules/jobs` | < 100 |
+| Failed job count | Job module error handler | 0 per 15 min window |
+| Job processing latency | Job module timing | < 30 s P95 |
+
+## Dashboards
+
+### Recommended Dashboard Layout
+
+Operators should configure their observability tool (Grafana, Datadog, CloudWatch, etc.) with the following panels:
+
+**Row 1 — Platform Health**
+- API health check status (pass/fail)
+- RPC endpoint reachability (testnet / mainnet / futurenet / local)
+- Active DB connections
+
+**Row 2 — Traffic**
+- HTTP request rate (req/s) by status code family (2xx, 4xx, 5xx)
+- P50 / P95 / P99 API response latency
+- Web SSR render rate
+
+**Row 3 — Errors**
+- API 5xx count (time series)
+- RPC proxy error count (time series)
+- Job failure count (time series)
+
+**Row 4 — Queues & Background Work**
+- Job queue depth
+- Job processing latency histogram
+- Audit log write rate
+
+### Minimal Local Dashboard (CLI)
+
+Run the health check script to get a quick snapshot without a full observability stack:
+
+```bash
+bash scripts/check-service-health.sh
+```
+
+The script checks:
+1. API `/health` endpoint reachability
+2. Database connectivity (via API health response)
+3. Each configured Soroban RPC endpoint
+4. Job queue depth (if API is reachable)
+
+Exit codes:
+- `0` — all checks passed
+- `1` — one or more checks failed (details printed to stdout)
+
+## Alerting Thresholds
+
+See [docs/runbooks.md](./runbooks.md) for the full alert routing and escalation policy. The thresholds below map directly to runbook entries.
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| API down | Health check fails 3× in 5 min | P1 |
+| High 5xx rate | > 5% of requests over 10 min | P2 |
+| RPC all endpoints down | All configured RPC URLs unreachable | P1 |
+| Job queue backed up | Depth > 500 for > 10 min | P2 |
+| DB slow queries | P95 > 1 s for > 5 min | P2 |
+| Build failure on main | CI `web` or `api` job fails | P3 |
+
+## Instrumentation Points
+
+### API Health Endpoint
+
+The API exposes `GET /health` (module: `apps/api/src/modules/health`). The response includes:
+
+```json
+{
+  "status": "ok",
+  "db": "ok",
+  "rpc": { "testnet": "ok", "mainnet": "degraded" },
+  "uptime": 3600
+}
+```
+
+### Structured Logging
+
+All API modules emit structured JSON logs. Key fields:
+
+| Field | Description |
+|-------|-------------|
+| `level` | `info` / `warn` / `error` |
+| `correlationId` | `x-request-id` header value |
+| `module` | NestJS module name |
+| `durationMs` | Request or operation duration |
+| `statusCode` | HTTP status (request logs only) |
+
+### RPC Correlation IDs
+
+The RPC proxy attaches `x-request-id` to every upstream call. Use this to correlate API logs with Soroban RPC provider logs.
+
+## Maintenance
+
+- Review thresholds quarterly or after each Wave launch.
+- Update this document when new modules are added to `apps/api/src/modules/`.
+- Run `bash scripts/check-service-health.sh` as part of pre-Wave validation (`npm run wave-prep`).

--- a/scripts/check-service-health.sh
+++ b/scripts/check-service-health.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# scripts/check-service-health.sh
+# DEVOPS-207: Baseline service health check for Wave operators.
+#
+# Usage:
+#   bash scripts/check-service-health.sh [--api-url <url>] [--timeout <seconds>]
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+#
+# Environment variables (override defaults):
+#   API_URL          API base URL (default: http://localhost:4000)
+#   CHECK_TIMEOUT    curl timeout in seconds (default: 5)
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+API_URL="${API_URL:-http://localhost:4000}"
+CHECK_TIMEOUT="${CHECK_TIMEOUT:-5}"
+ERRORS=0
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass()  { echo -e "${GREEN}✅ PASS${NC}  $*"; }
+fail()  { echo -e "${RED}❌ FAIL${NC}  $*"; ERRORS=$((ERRORS + 1)); }
+warn()  { echo -e "${YELLOW}⚠️  WARN${NC}  $*"; }
+info()  { echo -e "   ℹ️   $*"; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-url)  API_URL="$2";      shift 2 ;;
+    --timeout)  CHECK_TIMEOUT="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "  Soroban DevConsole — Service Health Check"
+echo "  $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "═══════════════════════════════════════════════════════"
+echo ""
+
+# ── Helper: HTTP GET with timeout ─────────────────────────────────────────────
+http_get() {
+  local url="$1"
+  curl --silent --max-time "${CHECK_TIMEOUT}" --write-out "%{http_code}" \
+       --output /tmp/sdc_health_body.json "${url}" 2>/dev/null || echo "000"
+}
+
+# ── 1. API Health Endpoint ────────────────────────────────────────────────────
+echo "── 1. API Backend (${API_URL}) ──────────────────────────"
+STATUS=$(http_get "${API_URL}/health")
+
+if [[ "${STATUS}" == "200" ]]; then
+  pass "API /health returned HTTP 200"
+  if command -v jq &>/dev/null && [[ -s /tmp/sdc_health_body.json ]]; then
+    DB_STATUS=$(jq -r '.db // "unknown"' /tmp/sdc_health_body.json 2>/dev/null)
+    UPTIME=$(jq -r '.uptime // "unknown"' /tmp/sdc_health_body.json 2>/dev/null)
+    info "db=${DB_STATUS}  uptime=${UPTIME}s"
+    if [[ "${DB_STATUS}" != "ok" ]]; then
+      fail "Database reported non-ok status: ${DB_STATUS}"
+    else
+      pass "Database connectivity"
+    fi
+  else
+    warn "jq not available or empty body — skipping detailed health parse"
+  fi
+elif [[ "${STATUS}" == "000" ]]; then
+  fail "API unreachable at ${API_URL} (connection refused or timeout)"
+else
+  fail "API /health returned HTTP ${STATUS}"
+fi
+echo ""
+
+# ── 2. RPC Endpoint Reachability ─────────────────────────────────────────────
+echo "── 2. Soroban RPC Endpoints ─────────────────────────────"
+
+# Load from .env if present, otherwise use known defaults
+ENV_FILE="apps/api/.env"
+if [[ -f "${ENV_FILE}" ]]; then
+  # shellcheck disable=SC1090
+  set -a; source "${ENV_FILE}"; set +a
+fi
+
+RPC_TESTNET="${SOROBAN_RPC_TESTNET_URL:-https://soroban-testnet.stellar.org:443}"
+RPC_MAINNET="${SOROBAN_RPC_MAINNET_URL:-}"
+RPC_FUTURENET="${SOROBAN_RPC_FUTURENET_URL:-}"
+RPC_LOCAL="${SOROBAN_RPC_LOCAL_URL:-http://localhost:8000/soroban/rpc}"
+
+check_rpc() {
+  local name="$1"
+  local url="$2"
+  if [[ -z "${url}" ]]; then
+    warn "${name}: not configured (skipping)"
+    return
+  fi
+  local code
+  code=$(curl --silent --max-time "${CHECK_TIMEOUT}" \
+              --write-out "%{http_code}" --output /dev/null \
+              --request POST "${url}" \
+              --header "Content-Type: application/json" \
+              --data '{"jsonrpc":"2.0","id":1,"method":"getHealth","params":[]}' \
+              2>/dev/null || echo "000")
+  if [[ "${code}" == "200" ]]; then
+    pass "${name}: reachable (HTTP 200)"
+  elif [[ "${code}" == "000" ]]; then
+    fail "${name}: unreachable (${url})"
+  else
+    warn "${name}: HTTP ${code} — may be degraded (${url})"
+  fi
+}
+
+check_rpc "testnet " "${RPC_TESTNET}"
+check_rpc "mainnet " "${RPC_MAINNET}"
+check_rpc "futurenet" "${RPC_FUTURENET}"
+check_rpc "local    " "${RPC_LOCAL}"
+echo ""
+
+# ── 3. Job Queue Depth (via API) ──────────────────────────────────────────────
+echo "── 3. Job Queue Depth ───────────────────────────────────"
+QUEUE_STATUS=$(http_get "${API_URL}/health/queues" 2>/dev/null || echo "000")
+
+if [[ "${QUEUE_STATUS}" == "200" ]] && command -v jq &>/dev/null; then
+  DEPTH=$(jq -r '.depth // 0' /tmp/sdc_health_body.json 2>/dev/null)
+  if [[ "${DEPTH}" -gt 500 ]]; then
+    fail "Job queue depth is ${DEPTH} (threshold: 500)"
+  elif [[ "${DEPTH}" -gt 100 ]]; then
+    warn "Job queue depth is ${DEPTH} (elevated, threshold: 100)"
+  else
+    pass "Job queue depth: ${DEPTH}"
+  fi
+elif [[ "${QUEUE_STATUS}" == "404" ]]; then
+  warn "/health/queues not implemented — skipping queue depth check"
+else
+  warn "Could not reach /health/queues (HTTP ${QUEUE_STATUS}) — skipping"
+fi
+echo ""
+
+# ── 4. CI / Build Artefacts ───────────────────────────────────────────────────
+echo "── 4. Local Build Artefacts ─────────────────────────────"
+if [[ -d "apps/web/.next" ]]; then
+  pass "apps/web/.next build directory exists"
+else
+  warn "apps/web/.next not found — web app may not be built"
+fi
+
+if [[ -f "apps/api/prisma/dev.db" ]] || [[ -n "${DATABASE_URL:-}" ]]; then
+  pass "Database file or DATABASE_URL present"
+else
+  warn "No local database file found (expected apps/api/prisma/dev.db)"
+fi
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════"
+if [[ "${ERRORS}" -eq 0 ]]; then
+  echo -e "${GREEN}  ✅ All checks passed${NC}"
+else
+  echo -e "${RED}  ❌ ${ERRORS} check(s) failed — see output above${NC}"
+fi
+echo "═══════════════════════════════════════════════════════"
+echo ""
+
+exit "${ERRORS}"


### PR DESCRIPTION
## Summary

Closes #351

Implements DEVOPS-207: baseline observability dashboards and service-level signals for Wave 5 operators.

## Changes

- **docs/observability.md** — defines service-level signals for API backend, web frontend, RPC proxy, and job queues; recommended dashboard layout; alerting thresholds; instrumentation points (health endpoint, structured logging, RPC correlation IDs)
- **scripts/check-service-health.sh** — CLI health check script covering API `/health`, RPC endpoint reachability, job queue depth, and local build artefacts; exits non-zero on failures with actionable output

## Testing

```bash
bash -n scripts/check-service-health.sh  # syntax check passes
bash scripts/check-service-health.sh     # runs against local stack
```

## Acceptance Criteria

- ✅ Workflow is documented and repeatable by maintainers
- ✅ Failures produce actionable output (non-zero exit + labelled messages)
- ✅ Integrates cleanly with existing monorepo and CI structure