### PR TITLE
feat(devops): add environment parity checklists for Wave launches

### DIFF
--- a/docs/env-parity-checklist.md
+++ b/docs/env-parity-checklist.md
@@ -1,0 +1,129 @@
+# Environment Parity Checklist for Wave Launches
+
+> DEVOPS-215 — Automated and manual parity checks across local, staging, and production-like environments.
+
+## Overview
+
+This checklist ensures that local, staging, and production-like environments are aligned before a Wave launch. Run `bash scripts/check-env-parity.sh` to automate the checks below.
+
+## Pre-Launch Checklist
+
+### 1. Environment Variables
+
+Run the parity script to verify all required variables are set:
+
+```bash
+bash scripts/check-env-parity.sh
+```
+
+#### API (`apps/api/.env`)
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `PORT` | ✅ | Must match `DEFAULT_API_PORT` in `packages/api-contracts/src/runtime-defaults.ts` |
+| `WEB_ORIGIN` | ✅ | Must match the deployed web app URL |
+| `DATABASE_URL` | ✅ | Must point to the correct DB for this environment |
+| `SOROBAN_RPC_TESTNET_URL` | ✅ | Required for testnet operations |
+| `SOROBAN_RPC_MAINNET_URL` | ⚠️ Optional | Required for mainnet operations |
+| `SOROBAN_RPC_FUTURENET_URL` | ⚠️ Optional | Required for futurenet operations |
+| `SOROBAN_RPC_LOCAL_URL` | ⚠️ Optional | Required for local network operations |
+| `RUNTIME_MODE` | ✅ | Must be `local`, `demo`, or `ci` |
+
+#### Web (`apps/web/.env.local`)
+
+| Variable | Required | Notes |
+|----------|----------|-------|
+| `NEXT_PUBLIC_API_URL` | ✅ | Must point to the API for this environment |
+| `NEXT_PUBLIC_RPC_TESTNET` | ✅ | Must match API's `SOROBAN_RPC_TESTNET_URL` |
+| `NEXT_PUBLIC_PASSPHRASE_TESTNET` | ✅ | Must match the network passphrase |
+| `NEXT_PUBLIC_PASSPHRASE_MAINNET` | ✅ | Must match the network passphrase |
+
+### 2. Port and URL Alignment
+
+Verify that documented defaults match the canonical source of truth:
+
+```bash
+npm run check-drift
+```
+
+This checks that `README.md`, `docs/architecture.md`, and `.env.example` files are aligned with `packages/api-contracts/src/runtime-defaults.ts`.
+
+### 3. Database
+
+- [ ] Database migrations are applied: `cd apps/api && npx prisma migrate deploy`
+- [ ] Database is seeded (if required): `cd apps/api && npx prisma db seed`
+- [ ] Database file is not a development snapshot (check `DATABASE_URL`)
+- [ ] Backup exists before launch (see `docs/backup-restore-drill.md`)
+
+### 4. RPC Endpoints
+
+- [ ] At least one Soroban RPC endpoint is reachable
+- [ ] RPC URLs are correct for the target network (testnet vs mainnet)
+- [ ] No local RPC URL (`localhost:8000`) is used in staging/production
+
+```bash
+bash scripts/check-service-health.sh
+```
+
+### 5. Build Artefacts
+
+- [ ] Web app is built: `npm run build -w web`
+- [ ] API is built: `npm run build -w api`
+- [ ] No stale `.next` cache from a different environment
+
+### 6. Security Configuration
+
+- [ ] `WEB_ORIGIN` is set to the correct domain (not `localhost`) in staging/production
+- [ ] No development secrets are present in staging/production env files
+- [ ] CORS is restricted to the correct origin
+- [ ] `RUNTIME_MODE` is set to `demo` or `ci` (not `local`) in non-local environments
+
+### 7. Dependency Integrity
+
+```bash
+npm run check-integrity
+```
+
+- [ ] `package-lock.json` is in sync with `package.json`
+- [ ] No workspace dependency version mismatches
+
+### 8. Full Wave-Prep Gate
+
+Run the complete pre-launch validation:
+
+```bash
+npm run wave-prep
+```
+
+This runs: drift check → integrity check → build order verification → branch workflow validation → SSR smoke test.
+
+## Environment Comparison Matrix
+
+| Check | Local | Staging | Production |
+|-------|-------|---------|------------|
+| `RUNTIME_MODE` | `local` | `demo` | `demo` |
+| `DATABASE_URL` | `file:./dev.db` | Hosted DB | Hosted DB |
+| `WEB_ORIGIN` | `http://localhost:3000` | `https://staging.example.com` | `https://app.example.com` |
+| RPC endpoints | Any | Testnet/Mainnet | Mainnet |
+| Build artefacts | Optional | Required | Required |
+| Migrations applied | Optional | Required | Required |
+
+## Automated Parity Script
+
+The `scripts/check-env-parity.sh` script automates the checks above. It:
+
+1. Verifies all required env vars are set in `apps/api/.env` and `apps/web/.env.local`.
+2. Checks that `WEB_ORIGIN` and `NEXT_PUBLIC_API_URL` are consistent with each other.
+3. Verifies port alignment against `packages/api-contracts/src/runtime-defaults.ts`.
+4. Warns if local-only values (e.g., `localhost`) are used in non-local `RUNTIME_MODE`.
+5. Checks that at least one RPC endpoint is configured.
+
+Exit codes:
+- `0` — all checks passed
+- `1` — one or more checks failed
+
+## Maintenance
+
+- Update this checklist when new required env vars are added.
+- Run `bash scripts/check-env-parity.sh` as part of every Wave launch preparation.
+- Add the script to `npm run wave-prep` if it is not already included.

--- a/scripts/check-env-parity.sh
+++ b/scripts/check-env-parity.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# scripts/check-env-parity.sh
+# DEVOPS-215: Environment parity check for Wave launches.
+#
+# Verifies that local, staging, and production-like environments are aligned:
+#   - Required env vars are present
+#   - WEB_ORIGIN and NEXT_PUBLIC_API_URL are consistent
+#   - Port values match the canonical runtime-defaults.ts
+#   - No localhost values in non-local RUNTIME_MODE
+#   - At least one RPC endpoint is configured
+#
+# Usage:
+#   bash scripts/check-env-parity.sh [--api-env <path>] [--web-env <path>]
+#
+# Exit codes:
+#   0 — all checks passed
+#   1 — one or more checks failed
+
+set -euo pipefail
+
+# ── Defaults ──────────────────────────────────────────────────────────────────
+API_ENV="${API_ENV:-apps/api/.env}"
+WEB_ENV="${WEB_ENV:-apps/web/.env.local}"
+ERRORS=0
+WARNINGS=0
+
+# ── Colours ───────────────────────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+pass()  { echo -e "${GREEN}✅ PASS${NC}  $*"; }
+fail()  { echo -e "${RED}❌ FAIL${NC}  $*"; ERRORS=$((ERRORS + 1)); }
+warn()  { echo -e "${YELLOW}⚠️  WARN${NC}  $*"; WARNINGS=$((WARNINGS + 1)); }
+info()  { echo -e "   ℹ️   $*"; }
+
+# ── Argument parsing ──────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --api-env) API_ENV="$2"; shift 2 ;;
+    --web-env) WEB_ENV="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+echo ""
+echo "═══════════════════════════════════════════════════════"
+echo "  Soroban DevConsole — Environment Parity Check"
+echo "  $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+echo "═══════════════════════════════════════════════════════"
+echo ""
+
+# ── Helper: read a value from an env file ─────────────────────────────────────
+get_env_val() {
+  local file="$1"
+  local key="$2"
+  grep -E "^${key}=" "${file}" 2>/dev/null | head -1 | sed 's/^[^=]*=//;s/^"//;s/"$//' || true
+}
+
+# ── Helper: check a required var is set ───────────────────────────────────────
+require_var() {
+  local file="$1"
+  local key="$2"
+  local val
+  val=$(get_env_val "${file}" "${key}")
+  if [[ -z "${val}" ]]; then
+    fail "${key} is not set in ${file}"
+  else
+    pass "${key} is set in ${file}"
+  fi
+}
+
+# ── 1. Env file existence ─────────────────────────────────────────────────────
+echo "── 1. Env File Existence ────────────────────────────────"
+if [[ -f "${API_ENV}" ]]; then
+  pass "API env file found: ${API_ENV}"
+else
+  fail "API env file not found: ${API_ENV}"
+  info "Copy apps/api/.env.example to ${API_ENV} and fill in values"
+fi
+
+if [[ -f "${WEB_ENV}" ]]; then
+  pass "Web env file found: ${WEB_ENV}"
+else
+  warn "Web env file not found: ${WEB_ENV}"
+  info "Copy apps/web/.env.example to ${WEB_ENV} and fill in values"
+fi
+echo ""
+
+# ── 2. Required API variables ─────────────────────────────────────────────────
+echo "── 2. Required API Variables ────────────────────────────"
+if [[ -f "${API_ENV}" ]]; then
+  require_var "${API_ENV}" "PORT"
+  require_var "${API_ENV}" "WEB_ORIGIN"
+  require_var "${API_ENV}" "DATABASE_URL"
+  require_var "${API_ENV}" "RUNTIME_MODE"
+
+  # At least one RPC endpoint
+  TESTNET_URL=$(get_env_val "${API_ENV}" "SOROBAN_RPC_TESTNET_URL")
+  MAINNET_URL=$(get_env_val "${API_ENV}" "SOROBAN_RPC_MAINNET_URL")
+  FUTURENET_URL=$(get_env_val "${API_ENV}" "SOROBAN_RPC_FUTURENET_URL")
+  LOCAL_URL=$(get_env_val "${API_ENV}" "SOROBAN_RPC_LOCAL_URL")
+
+  if [[ -z "${TESTNET_URL}" && -z "${MAINNET_URL}" && -z "${FUTURENET_URL}" && -z "${LOCAL_URL}" ]]; then
+    fail "No Soroban RPC endpoint configured in ${API_ENV}"
+    info "Set at least one of: SOROBAN_RPC_TESTNET_URL, SOROBAN_RPC_MAINNET_URL, SOROBAN_RPC_FUTURENET_URL, SOROBAN_RPC_LOCAL_URL"
+  else
+    pass "At least one Soroban RPC endpoint is configured"
+    [[ -n "${TESTNET_URL}" ]]  && info "testnet:  ${TESTNET_URL}"
+    [[ -n "${MAINNET_URL}" ]]  && info "mainnet:  ${MAINNET_URL}"
+    [[ -n "${FUTURENET_URL}" ]] && info "futurenet: ${FUTURENET_URL}"
+    [[ -n "${LOCAL_URL}" ]]    && info "local:    ${LOCAL_URL}"
+  fi
+fi
+echo ""
+
+# ── 3. Required Web variables ─────────────────────────────────────────────────
+echo "── 3. Required Web Variables ────────────────────────────"
+if [[ -f "${WEB_ENV}" ]]; then
+  require_var "${WEB_ENV}" "NEXT_PUBLIC_API_URL"
+  require_var "${WEB_ENV}" "NEXT_PUBLIC_RPC_TESTNET"
+  require_var "${WEB_ENV}" "NEXT_PUBLIC_PASSPHRASE_TESTNET"
+  require_var "${WEB_ENV}" "NEXT_PUBLIC_PASSPHRASE_MAINNET"
+fi
+echo ""
+
+# ── 4. Cross-env consistency ──────────────────────────────────────────────────
+echo "── 4. Cross-Environment Consistency ────────────────────"
+if [[ -f "${API_ENV}" && -f "${WEB_ENV}" ]]; then
+  API_PORT=$(get_env_val "${API_ENV}" "PORT")
+  WEB_API_URL=$(get_env_val "${WEB_ENV}" "NEXT_PUBLIC_API_URL")
+  API_WEB_ORIGIN=$(get_env_val "${API_ENV}" "WEB_ORIGIN")
+
+  # Check that NEXT_PUBLIC_API_URL port matches API PORT
+  if [[ -n "${API_PORT}" && -n "${WEB_API_URL}" ]]; then
+    URL_PORT=$(echo "${WEB_API_URL}" | grep -oE ':[0-9]+' | tr -d ':' || true)
+    if [[ -n "${URL_PORT}" && "${URL_PORT}" != "${API_PORT}" ]]; then
+      fail "Port mismatch: API PORT=${API_PORT} but NEXT_PUBLIC_API_URL uses port ${URL_PORT}"
+    else
+      pass "API port is consistent between API and Web env files"
+    fi
+  fi
+
+  # Check WEB_ORIGIN matches web app URL pattern
+  if [[ -n "${API_WEB_ORIGIN}" && -n "${WEB_API_URL}" ]]; then
+    # Extract host from WEB_API_URL to compare with WEB_ORIGIN host
+    API_HOST=$(echo "${WEB_API_URL}" | sed 's|https\?://||;s|/.*||;s|:[0-9]*||')
+    ORIGIN_HOST=$(echo "${API_WEB_ORIGIN}" | sed 's|https\?://||;s|/.*||;s|:[0-9]*||')
+    if [[ "${API_HOST}" != "${ORIGIN_HOST}" ]]; then
+      warn "WEB_ORIGIN host (${ORIGIN_HOST}) differs from NEXT_PUBLIC_API_URL host (${API_HOST}) — verify this is intentional"
+    else
+      pass "WEB_ORIGIN and NEXT_PUBLIC_API_URL are on the same host"
+    fi
+  fi
+fi
+echo ""
+
+# ── 5. Port alignment with runtime-defaults.ts ───────────────────────────────
+echo "── 5. Port Alignment with runtime-defaults.ts ──────────"
+DEFAULTS_FILE="packages/api-contracts/src/runtime-defaults.ts"
+if [[ -f "${DEFAULTS_FILE}" ]]; then
+  CANONICAL_API_PORT=$(grep -oE 'DEFAULT_API_PORT = [0-9]+' "${DEFAULTS_FILE}" | grep -oE '[0-9]+' || true)
+  CANONICAL_WEB_PORT=$(grep -oE 'DEFAULT_WEB_PORT = [0-9]+' "${DEFAULTS_FILE}" | grep -oE '[0-9]+' || true)
+
+  if [[ -n "${CANONICAL_API_PORT}" && -f "${API_ENV}" ]]; then
+    ENV_API_PORT=$(get_env_val "${API_ENV}" "PORT")
+    if [[ -n "${ENV_API_PORT}" && "${ENV_API_PORT}" != "${CANONICAL_API_PORT}" ]]; then
+      fail "API PORT=${ENV_API_PORT} does not match canonical DEFAULT_API_PORT=${CANONICAL_API_PORT}"
+    else
+      pass "API PORT aligns with runtime-defaults.ts (${CANONICAL_API_PORT})"
+    fi
+  fi
+
+  if [[ -n "${CANONICAL_WEB_PORT}" && -f "${WEB_ENV}" ]]; then
+    WEB_API_URL=$(get_env_val "${WEB_ENV}" "NEXT_PUBLIC_API_URL")
+    # We check that the web env doesn't accidentally use the web port for the API URL
+    URL_PORT=$(echo "${WEB_API_URL}" | grep -oE ':[0-9]+' | tr -d ':' || true)
+    if [[ -n "${URL_PORT}" && "${URL_PORT}" == "${CANONICAL_WEB_PORT}" ]]; then
+      warn "NEXT_PUBLIC_API_URL appears to use the web port (${CANONICAL_WEB_PORT}) — expected the API port (${CANONICAL_API_PORT:-?})"
+    fi
+  fi
+else
+  warn "runtime-defaults.ts not found at ${DEFAULTS_FILE} — skipping canonical port check"
+fi
+echo ""
+
+# ── 6. Non-local environment warnings ────────────────────────────────────────
+echo "── 6. Non-Local Environment Warnings ───────────────────"
+if [[ -f "${API_ENV}" ]]; then
+  RUNTIME_MODE=$(get_env_val "${API_ENV}" "RUNTIME_MODE")
+  if [[ "${RUNTIME_MODE}" != "local" && "${RUNTIME_MODE}" != "" ]]; then
+    info "RUNTIME_MODE=${RUNTIME_MODE} — checking for localhost values..."
+
+    WEB_ORIGIN=$(get_env_val "${API_ENV}" "WEB_ORIGIN")
+    if echo "${WEB_ORIGIN}" | grep -q "localhost"; then
+      warn "WEB_ORIGIN contains 'localhost' but RUNTIME_MODE=${RUNTIME_MODE}"
+    else
+      pass "WEB_ORIGIN does not use localhost in ${RUNTIME_MODE} mode"
+    fi
+
+    LOCAL_RPC=$(get_env_val "${API_ENV}" "SOROBAN_RPC_LOCAL_URL")
+    if [[ -n "${LOCAL_RPC}" ]] && echo "${LOCAL_RPC}" | grep -q "localhost"; then
+      warn "SOROBAN_RPC_LOCAL_URL is set to a localhost URL in ${RUNTIME_MODE} mode — ensure this is intentional"
+    fi
+  else
+    info "RUNTIME_MODE=local — skipping non-local checks"
+  fi
+fi
+echo ""
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo "═══════════════════════════════════════════════════════"
+if [[ "${ERRORS}" -eq 0 && "${WARNINGS}" -eq 0 ]]; then
+  echo -e "${GREEN}  ✅ All parity checks passed${NC}"
+elif [[ "${ERRORS}" -eq 0 ]]; then
+  echo -e "${YELLOW}  ⚠️  ${WARNINGS} warning(s) — review before Wave launch${NC}"
+else
+  echo -e "${RED}  ❌ ${ERRORS} error(s), ${WARNINGS} warning(s) — fix before Wave launch${NC}"
+fi
+echo "═══════════════════════════════════════════════════════"
+echo ""
+
+exit "${ERRORS}"


### PR DESCRIPTION
## Summary

Closes #359

Implements DEVOPS-215: automated and documented parity checks across local, staging, and production-like environments.

## Changes

- **docs/env-parity-checklist.md** — pre-launch checklist covering:
  - Required API and web env vars with notes
  - Port and URL alignment (`npm run check-drift`)
  - Database migration and backup steps
  - RPC endpoint reachability
  - Build artefacts
  - Security configuration (WEB_ORIGIN, RUNTIME_MODE)
  - Dependency integrity
  - Full wave-prep gate
  - Environment comparison matrix (local / staging / production)
- **scripts/check-env-parity.sh** — automated parity script that checks:
  1. Env file existence (`apps/api/.env`, `apps/web/.env.local`)
  2. Required API variables (PORT, WEB_ORIGIN, DATABASE_URL, RUNTIME_MODE, ≥1 RPC URL)
  3. Required web variables (NEXT_PUBLIC_API_URL, RPC URLs, passphrases)
  4. Cross-env consistency (port in NEXT_PUBLIC_API_URL matches API PORT)
  5. Port alignment against `packages/api-contracts/src/runtime-defaults.ts`
  6. Localhost warnings when RUNTIME_MODE is not `local`

## Testing

```bash
bash -n scripts/check-env-parity.sh   # syntax check
bash scripts/check-env-parity.sh      # run against local env files
```

## Acceptance Criteria

- ✅ Workflow is automated and documented well enough to be used repeatedly
- ✅ Failures produce actionable output (labelled PASS/FAIL/WARN with hints)
- ✅ Integrates cleanly with existing monorepo and CI structure