### PR TITLE
# [DEVOPS-216] Generate release evidence bundles for audits and wave …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -307,7 +307,9 @@ jobs:
           fi
           echo "✅ All required checks passed."
   # DEVOPS-212: Wave-prep gate — runs the full release-readiness sequence.
-  # Only triggers on devops-relevant file changes or push to main.
+  # For audit-ready artifacts (commit range, check logs, health notes), use the
+  # Release Candidate workflow or: npm run release-evidence -- --wave <id>
+  # See docs/release-evidence-bundle.md (DEVOPS-216).
   wave-prep:
     name: Wave Prep
     needs: [changes, devops]

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -295,36 +295,79 @@ jobs:
             echo "- $icon **$job**: $result" >> $GITHUB_STEP_SUMMARY
           done
 
-      - name: Package RC manifest
-        if: needs.rc-gate.result != 'failure'
-        env:
-          WAVE: ${{ github.event.inputs.wave_label || github.ref_name }}
+      - name: Setup Node for evidence bundle
+        if: success()
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+
+      - name: Install dependencies for evidence bundle
+        if: success()
+        run: npm ci
+
+      - name: Generate Prisma client (evidence checks)
+        if: success()
+        run: npm run prisma:generate -w api
+
+      - name: Build shared packages (evidence checks)
+        if: success()
+        run: npx turbo run build --filter=./packages/*
+
+      - name: Write CI layer results
+        if: success()
         run: |
-          mkdir -p rc-manifest
-          cat > rc-manifest/release-candidate.json <<EOF
+          cat > /tmp/ci-layer-results.json <<EOF
           {
-            "wave": "$WAVE",
-            "sha": "${{ github.sha }}",
-            "ref": "${{ github.ref }}",
-            "run_id": "${{ github.run_id }}",
-            "actor": "${{ github.actor }}",
-            "timestamp": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-            "layers": {
-              "devops": "${{ needs.devops.result }}",
-              "web": "${{ needs.web.result }}",
-              "api": "${{ needs.api.result }}",
-              "api-schema": "${{ needs.api-schema.result }}",
-              "api-contracts": "${{ needs.api-contracts.result }}",
-              "contracts": "${{ needs.contracts.result }}",
-              "e2e": "${{ needs.e2e.result }}"
-            }
+            "devops": "${{ needs.devops.result }}",
+            "web": "${{ needs.web.result }}",
+            "api": "${{ needs.api.result }}",
+            "api-schema": "${{ needs.api-schema.result }}",
+            "api-contracts": "${{ needs.api-contracts.result }}",
+            "contracts": "${{ needs.contracts.result }}",
+            "e2e": "${{ needs.e2e.result }}"
           }
           EOF
 
-      - name: Upload RC manifest
+      - name: Generate release evidence bundle
+        if: success()
+        env:
+          WAVE: ${{ github.event.inputs.wave_label || github.ref_name }}
+        run: |
+          npx tsx scripts/generate-release-evidence.ts \
+            --wave "$WAVE" \
+            --base origin/main \
+            --quick \
+            --layer-results /tmp/ci-layer-results.json \
+            --github-run-id "${{ github.run_id }}" \
+            --github-sha "${{ github.sha }}" \
+            --github-ref "${{ github.ref }}" \
+            --github-actor "${{ github.actor }}" \
+            --github-repository "${{ github.repository }}"
+
+      - name: Write evidence summary
+        if: always()
+        run: |
+          if [ -f release-evidence/EVIDENCE.md ]; then
+            echo "## Release Evidence Bundle" >> $GITHUB_STEP_SUMMARY
+            cat release-evidence/EVIDENCE.md >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload release evidence bundle
         if: always()
         uses: actions/upload-artifact@v4
         with:
+          name: release-evidence-${{ github.run_id }}
+          path: |
+            release-evidence/
+            release-evidence-bundle.tar.gz
+          retention-days: 90
+
+      # Legacy manifest path for consumers expecting rc-manifest/<run_id>
+      - name: Upload RC manifest (compat)
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
           name: rc-manifest-${{ github.run_id }}
-          path: rc-manifest/
+          path: release-evidence/manifest.json
           retention-days: 90

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ Thumbs.db
 # Optional: coverage
 coverage
 .backups/
+
+# DEVOPS-216: release evidence bundles (generated locally or in CI)
+release-evidence/
+release-evidence-bundle.tar.gz

--- a/docs/release-candidate.md
+++ b/docs/release-candidate.md
@@ -42,9 +42,22 @@ gh workflow run release-candidate.yml \
   --field wave_label=wave-5
 ```
 
-## RC Manifest
+## Release evidence bundle (DEVOPS-216)
 
-On success, `rc-gate` uploads a `rc-manifest-<run_id>` artifact (retained 90 days) containing `release-candidate.json`:
+On success, `rc-gate` also runs `scripts/generate-release-evidence.ts` and uploads a **`release-evidence-<run_id>`** artifact (90 days) containing:
+
+- `manifest.json` — structured metadata, git range, check results, CI layers
+- `EVIDENCE.md` — maintainer/auditor report with repro commands
+- `checks/*.log` — full validation output
+- `git/` — commit range files
+- `service-health.json` — health probe notes
+- `release-evidence-bundle.tar.gz` — portable archive
+
+See [release-evidence-bundle.md](./release-evidence-bundle.md) for local usage and failure interpretation.
+
+## RC Manifest (legacy)
+
+`rc-gate` uploads `manifest.json` from the evidence bundle as `rc-manifest-<run_id>` for backward compatibility. The canonical format matches:
 
 ```json
 {
@@ -100,4 +113,5 @@ If any layer fails, fix the root cause on the release branch, push, and re-run. 
 |----------|-----------|----------|
 | `rc-bundle-analysis-<run_id>` | 30 days | Next.js bundle analysis from the web build |
 | `rc-playwright-report-<run_id>` | 30 days | Playwright HTML report from E2E tests |
-| `rc-manifest-<run_id>` | 90 days | JSON manifest with layer results and metadata |
+| `release-evidence-<run_id>` | 90 days | Full evidence bundle (manifest, logs, git range, tarball) |
+| `rc-manifest-<run_id>` | 90 days | `manifest.json` only (compat alias) |

--- a/docs/release-evidence-bundle.md
+++ b/docs/release-evidence-bundle.md
@@ -1,0 +1,152 @@
+# Release Evidence Bundle (DEVOPS-216)
+
+> Automated audit artifact for wave-prep release candidates. Builds on [DEVOPS-204](./release-candidate.md).
+
+## Overview
+
+The release evidence bundle captures everything a maintainer or auditor needs to sign off on a wave cutover:
+
+| Artifact | Contents |
+|----------|----------|
+| `manifest.json` | Machine-readable summary (git range, checks, CI layers, health probes) |
+| `EVIDENCE.md` | Human-readable report with repro commands for failures |
+| `git/` | Commit range, oneline log, metadata |
+| `checks/*.log` | Full stdout/stderr for each validation command |
+| `service-health.json` | Best-effort API/web health probe notes |
+| `release-evidence-bundle.tar.gz` | Compressed archive of the directory |
+
+Failures print **actionable repro steps** to the console and mark failing checks in `EVIDENCE.md` — no silent drift.
+
+## When to generate
+
+| Context | Command |
+|---------|---------|
+| **Local wave prep** | `npm run release-evidence -- --wave wave-5` |
+| **Quick local check** (skip SSR smoke) | `npm run release-evidence -- --wave wave-5 --quick` |
+| **CI** | Automatic in `release-candidate.yml` → `rc-gate` job |
+| **Metadata only** | `npm run release-evidence -- --wave wave-5 --skip-checks --layer-results ./layers.json` |
+
+## Local usage
+
+```bash
+# Full bundle (includes SSR smoke — builds web app)
+npm run release-evidence -- --wave wave-5 --base origin/main
+
+# Faster iteration (skips smoke-ssr-prerender)
+npm run release-evidence -- --wave wave-5 --quick
+
+# Custom output directory
+npm run release-evidence -- --wave wave-5 --output ./artifacts/rc-wave-5
+```
+
+### Prerequisites
+
+- `git fetch origin main` so commit range resolves
+- `npm ci` at repo root
+- For `verify-build-order`: build shared packages first (`npx turbo run build --filter=./packages/*`)
+- For `prisma-validate`: `npm run prisma:generate -w api`
+
+### Exit codes
+
+| Code | Meaning |
+|------|---------|
+| `0` | All required checks passed; bundle ready for archive |
+| `1` | One or more required checks failed, or CI layer results include `failure` |
+
+## Checks included
+
+| ID | Category | Required | Skipped with `--quick` |
+|----|----------|----------|------------------------|
+| `check-drift` | config | yes | |
+| `check-integrity` | config | yes | |
+| `validate-branch-workflow` | validation | no (warn) | |
+| `verify-build-order` | build | yes | |
+| `prisma-validate` | validation | yes | |
+| `verify-migrations` | validation | no (warn) | |
+| `smoke-ssr-prerender` | build | no (warn) | yes |
+
+## CI integration
+
+The **Release Candidate** workflow (`/.github/workflows/release-candidate.yml`) runs after all validation layers pass:
+
+1. Writes CI layer results to JSON
+2. Runs `generate-release-evidence.ts` with `--quick` and GitHub metadata
+3. Uploads `release-evidence-<run_id>` artifact (90-day retention)
+4. Appends `EVIDENCE.md` to the GitHub Actions step summary
+
+Trigger via Actions UI or:
+
+```bash
+gh workflow run release-candidate.yml \
+  --ref release/wave-5 \
+  --field wave_label=wave-5
+```
+
+Download the bundle:
+
+```bash
+gh run download <run_id> --name release-evidence-<run_id>
+tar -xzf release-evidence-bundle.tar.gz
+```
+
+## manifest.json schema
+
+```json
+{
+  "schemaVersion": "1.0",
+  "wave": "wave-5",
+  "timestamp": "2026-05-29T12:00:00Z",
+  "git": {
+    "head": "<sha>",
+    "branch": "release/wave-5",
+    "baseRef": "origin/main",
+    "baseSha": "<sha>",
+    "commitRange": "<base>..<head>",
+    "commitCount": 42
+  },
+  "ci": {
+    "runId": "12345678",
+    "sha": "<sha>",
+    "ref": "refs/heads/release/wave-5",
+    "actor": "maintainer",
+    "repository": "owner/repo"
+  },
+  "ciLayers": {
+    "devops": "success",
+    "web": "success"
+  },
+  "checks": [ { "id": "check-drift", "status": "pass", "logFile": "checks/check-drift.log" } ],
+  "serviceHealth": { "probes": [ { "name": "api", "status": "unreachable" } ] },
+  "summary": { "ready": true, "requiredChecksPassed": true, "ciLayersPassed": true }
+}
+```
+
+## Interpreting failures
+
+Example console output:
+
+```
+❌ Release evidence bundle has failing required checks:
+
+  • Runtime config drift (check-drift)
+    Reproduce: npm run check-drift
+    Log: release-evidence/checks/check-drift.log
+    Summary: Total drifts found: 2
+```
+
+Open the log file for full command output. Fix locally, re-run `npm run release-evidence`, and archive the new bundle.
+
+## Wave cutover checklist
+
+1. Run [Release Candidate](./release-candidate.md) workflow on `release/<wave>`.
+2. Download `release-evidence-<run_id>` artifact.
+3. Confirm `manifest.json` → `summary.ready` is `true`.
+4. Review `EVIDENCE.md` and `git/commits-oneline.txt` for the intended commit range.
+5. Archive the tarball in your wave audit record.
+6. Proceed with cutover only when CI layers and required checks are green.
+
+## Related
+
+- [release-candidate.md](./release-candidate.md) — RC workflow and layer matrix
+- `npm run wave-prep` — local subset of validation (does not produce a bundle)
+- `scripts/generate-release-evidence.ts` — bundle generator implementation

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check-integrity": "tsx scripts/check-dependency-integrity.ts",
     "audit:ci": "turbo run audit --filter=web --filter=api",
     "wave-prep": "npm run check-drift && npm run check-integrity && tsx scripts/verify-build-order.ts && tsx scripts/validate-branch-workflow.ts && tsx scripts/smoke-ssr-prerender.ts",
+    "release-evidence": "tsx scripts/generate-release-evidence.ts",
     "deploy:contracts": "bash scripts/deploy-test-suite.sh"
   },
   "devDependencies": {

--- a/scripts/generate-release-evidence.ts
+++ b/scripts/generate-release-evidence.ts
@@ -1,0 +1,513 @@
+/**
+ * DEVOPS-216: Generate release evidence bundles for audits and wave readiness.
+ *
+ * Captures commit range, validation outputs, config checks, and service health
+ * notes into a repeatable artifact for maintainers and auditors.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-release-evidence.ts --wave wave-5
+ *   npx tsx scripts/generate-release-evidence.ts --wave wave-5 --base origin/main --quick
+ */
+
+import { execSync, spawnSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+type CheckStatus = "pass" | "fail" | "warn" | "skip";
+
+interface CheckDefinition {
+  id: string;
+  name: string;
+  category: "config" | "validation" | "build";
+  command: string;
+  repro: string;
+  required: boolean;
+  /** Skip when --quick */
+  heavy?: boolean;
+}
+
+interface CheckResult {
+  id: string;
+  name: string;
+  category: string;
+  status: CheckStatus;
+  exitCode: number | null;
+  durationMs: number;
+  reproCommand: string;
+  summary: string;
+  logFile: string;
+}
+
+interface CliOptions {
+  wave: string;
+  base: string;
+  output: string;
+  quick: boolean;
+  skipChecks: boolean;
+  layerResultsPath?: string;
+  github?: {
+    runId?: string;
+    sha?: string;
+    ref?: string;
+    actor?: string;
+    repository?: string;
+  };
+}
+
+const CHECKS: CheckDefinition[] = [
+  {
+    id: "check-drift",
+    name: "Runtime config drift",
+    category: "config",
+    command: "npm run check-drift",
+    repro: "npm run check-drift",
+    required: true,
+  },
+  {
+    id: "check-integrity",
+    name: "Dependency integrity",
+    category: "config",
+    command: "npm run check-integrity",
+    repro: "npm run check-integrity",
+    required: true,
+  },
+  {
+    id: "validate-branch-workflow",
+    name: "Branch workflow",
+    category: "validation",
+    command: "npx tsx scripts/validate-branch-workflow.ts",
+    repro: "npx tsx scripts/validate-branch-workflow.ts",
+    required: false,
+  },
+  {
+    id: "verify-build-order",
+    name: "Shared package build order",
+    category: "build",
+    command: "npx tsx scripts/verify-build-order.ts",
+    repro: "npx tsx scripts/verify-build-order.ts",
+    required: true,
+  },
+  {
+    id: "prisma-validate",
+    name: "Prisma schema",
+    category: "validation",
+    command:
+      "npm run prisma:generate -w api && npx prisma validate --schema apps/api/prisma/schema.prisma",
+    repro:
+      "npm run prisma:generate -w api && npx prisma validate --schema apps/api/prisma/schema.prisma",
+    required: true,
+  },
+  {
+    id: "verify-migrations",
+    name: "Migration consistency",
+    category: "validation",
+    command: "bash scripts/verify-migrations.sh",
+    repro: "bash scripts/verify-migrations.sh",
+    required: false,
+  },
+  {
+    id: "smoke-ssr-prerender",
+    name: "SSR / prerender smoke",
+    category: "build",
+    command: "npx tsx scripts/smoke-ssr-prerender.ts",
+    repro: "npx tsx scripts/smoke-ssr-prerender.ts",
+    required: false,
+    heavy: true,
+  },
+];
+
+function parseArgs(): CliOptions {
+  const args = process.argv.slice(2);
+  let wave = "";
+  let base = "origin/main";
+  let output = "release-evidence";
+  let quick = false;
+  let skipChecks = false;
+  let layerResultsPath: string | undefined;
+  const github: CliOptions["github"] = {};
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--wave" && args[i + 1]) wave = args[++i];
+    else if (arg === "--base" && args[i + 1]) base = args[++i];
+    else if (arg === "--output" && args[i + 1]) output = args[++i];
+    else if (arg === "--quick") quick = true;
+    else if (arg === "--skip-checks") skipChecks = true;
+    else if (arg === "--layer-results" && args[i + 1]) layerResultsPath = args[++i];
+    else if (arg === "--github-run-id" && args[i + 1]) github.runId = args[++i];
+    else if (arg === "--github-sha" && args[i + 1]) github.sha = args[++i];
+    else if (arg === "--github-ref" && args[i + 1]) github.ref = args[++i];
+    else if (arg === "--github-actor" && args[i + 1]) github.actor = args[++i];
+    else if (arg === "--github-repository" && args[i + 1]) github.repository = args[++i];
+    else if (arg === "--help" || arg === "-h") {
+      console.log(`Usage: npx tsx scripts/generate-release-evidence.ts --wave <id> [options]
+
+Options:
+  --wave <id>              Wave label (required), e.g. wave-5
+  --base <ref>             Commit range base (default: origin/main)
+  --output <dir>           Output directory (default: release-evidence)
+  --quick                  Skip heavy checks (SSR smoke)
+  --skip-checks            Only capture git metadata and CI layer results
+  --layer-results <path>   JSON file with CI job results
+  --github-run-id <id>     Embed CI run metadata in manifest
+  --github-sha <sha>
+  --github-ref <ref>
+  --github-actor <actor>
+  --github-repository <owner/repo>
+`);
+      process.exit(0);
+    }
+  }
+
+  if (!wave) {
+    console.error("❌ --wave is required (e.g. --wave wave-5)");
+    process.exit(1);
+  }
+
+  return { wave, base, output, quick, skipChecks, layerResultsPath, github };
+}
+
+function git(cmd: string): string {
+  return execSync(cmd, { cwd: ROOT, encoding: "utf-8" }).trim();
+}
+
+function captureGitEvidence(outDir: string, baseRef: string): Record<string, unknown> {
+  const gitDir = path.join(outDir, "git");
+  fs.mkdirSync(gitDir, { recursive: true });
+
+  const head = git("git rev-parse HEAD");
+  const branch = git("git rev-parse --abbrev-ref HEAD");
+  let remoteUrl = "unknown";
+  try {
+    remoteUrl = git("git remote get-url origin");
+  } catch {
+    /* optional */
+  }
+
+  let baseSha = "";
+  let commitRange = "";
+  let oneline = "";
+
+  try {
+    baseSha = git(`git merge-base ${baseRef} HEAD`);
+    oneline = git(`git log ${baseSha}..HEAD --oneline`);
+    commitRange = `${baseSha}..${head}`;
+  } catch {
+    oneline = `(could not resolve base ref "${baseRef}" — fetch it first)`;
+    commitRange = `unknown..${head}`;
+  }
+
+  const meta = {
+    head,
+    branch,
+    remoteUrl,
+    baseRef,
+    baseSha: baseSha || null,
+    commitRange,
+    commitCount: oneline ? oneline.split("\n").filter(Boolean).length : 0,
+    capturedAt: new Date().toISOString(),
+  };
+
+  fs.writeFileSync(path.join(gitDir, "metadata.json"), JSON.stringify(meta, null, 2));
+  fs.writeFileSync(path.join(gitDir, "commits-oneline.txt"), oneline || "(no commits in range)\n");
+  fs.writeFileSync(
+    path.join(gitDir, "commit-range.txt"),
+    `Range: ${commitRange}\nBranch: ${branch}\nHEAD: ${head}\n`,
+  );
+
+  return meta;
+}
+
+function runCheck(def: CheckDefinition, checksDir: string): CheckResult {
+  const logFile = path.join(checksDir, `${def.id}.log`);
+  const start = Date.now();
+  const result = spawnSync(def.command, {
+    shell: true,
+    cwd: ROOT,
+    encoding: "utf-8",
+    env: process.env,
+  });
+  const durationMs = Date.now() - start;
+
+  const stdout = result.stdout ?? "";
+  const stderr = result.stderr ?? "";
+  fs.writeFileSync(logFile, `${stdout}\n${stderr}`.trim() + "\n");
+
+  const exitCode = result.status;
+  let status: CheckStatus = "pass";
+  if (exitCode !== 0) {
+    status = def.required ? "fail" : "warn";
+  }
+
+  const lastLine =
+    (stderr || stdout)
+      .split("\n")
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .pop() ?? "(no output)";
+
+  return {
+    id: def.id,
+    name: def.name,
+    category: def.category,
+    status,
+    exitCode,
+    durationMs,
+    reproCommand: def.repro,
+    summary: lastLine.slice(0, 240),
+    logFile: path.relative(ROOT, logFile),
+  };
+}
+
+async function probeServiceHealth(): Promise<Record<string, unknown>> {
+  const apiPort = 4000;
+  const webPort = 3000;
+  const probes = [
+    { name: "api", url: `http://localhost:${apiPort}/api/health` },
+    { name: "web", url: `http://localhost:${webPort}/` },
+  ];
+
+  const results = [];
+
+  for (const probe of probes) {
+    const entry: Record<string, unknown> = {
+      name: probe.name,
+      url: probe.url,
+      probedAt: new Date().toISOString(),
+    };
+    try {
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), 4000);
+      const res = await fetch(probe.url, { signal: controller.signal });
+      clearTimeout(timer);
+      let body: unknown = null;
+      const text = await res.text();
+      try {
+        body = JSON.parse(text);
+      } catch {
+        body = text.slice(0, 200);
+      }
+      entry.httpStatus = res.status;
+      entry.status = res.ok ? "reachable" : "degraded";
+      entry.body = body;
+    } catch (err) {
+      entry.status = "unreachable";
+      entry.error = err instanceof Error ? err.message : String(err);
+      entry.note =
+        probe.name === "api"
+          ? "Start the API locally (npm run dev in apps/api) to include a live health snapshot."
+          : "Start the web app locally to include a live reachability snapshot.";
+    }
+    results.push(entry);
+  }
+
+  return {
+    note: "Probes are best-effort. CI bundles typically show unreachable unless services run in the same job.",
+    probes: results,
+  };
+}
+
+function loadLayerResults(filePath: string): Record<string, string> | null {
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, "utf-8")) as Record<string, string>;
+}
+
+function writeHumanReport(
+  outDir: string,
+  manifest: Record<string, unknown>,
+  checkResults: CheckResult[],
+): void {
+  const lines: string[] = [
+    "# Release Evidence Bundle",
+    "",
+    `**Wave:** ${manifest.wave}`,
+    `**Generated:** ${manifest.timestamp}`,
+    `**HEAD:** \`${manifest.git?.head ?? "unknown"}\``,
+    `**Commit range:** \`${manifest.git?.commitRange ?? "unknown"}\` (${manifest.git?.commitCount ?? 0} commits)`,
+    "",
+    "## CI layer results",
+    "",
+  ];
+
+  const layers = manifest.ciLayers as Record<string, string> | undefined;
+  if (layers) {
+    for (const [job, result] of Object.entries(layers)) {
+      const icon = result === "success" ? "✅" : result === "skipped" ? "⏭️" : "❌";
+      lines.push(`- ${icon} **${job}**: ${result}`);
+    }
+  } else {
+    lines.push("_No CI layer results embedded (local run)._");
+  }
+
+  lines.push("", "## Validation & config checks", "");
+
+  for (const c of checkResults) {
+    const icon =
+      c.status === "pass" ? "✅" : c.status === "warn" ? "⚠️" : c.status === "skip" ? "⏭️" : "❌";
+    lines.push(`- ${icon} **${c.name}** (\`${c.id}\`) — ${c.summary}`);
+    if (c.status === "fail" || c.status === "warn") {
+      lines.push(`  - Reproduce: \`${c.reproCommand}\``);
+      lines.push(`  - Log: \`${c.logFile}\``);
+    }
+  }
+
+  lines.push("", "## Service health", "");
+  const health = manifest.serviceHealth as { probes?: Array<{ name: string; status: string }> };
+  if (health?.probes) {
+    for (const p of health.probes) {
+      lines.push(`- **${p.name}**: ${p.status}`);
+    }
+  }
+
+  lines.push("", "## Audit checklist", "");
+  lines.push("- [ ] Commit range matches the intended release branch");
+  lines.push("- [ ] All required checks passed (no ❌ above)");
+  lines.push("- [ ] CI layer matrix green (if applicable)");
+  lines.push("- [ ] Bundle archived for the wave cutover record");
+  lines.push("");
+
+  fs.writeFileSync(path.join(outDir, "EVIDENCE.md"), lines.join("\n"));
+}
+
+function printActionableFailures(checkResults: CheckResult[]): void {
+  const failures = checkResults.filter((c) => c.status === "fail");
+  if (!failures.length) return;
+
+  console.error("\n❌ Release evidence bundle has failing required checks:\n");
+  for (const f of failures) {
+    console.error(`  • ${f.name} (${f.id})`);
+    console.error(`    Reproduce: ${f.reproCommand}`);
+    console.error(`    Log: ${f.logFile}`);
+    console.error(`    Summary: ${f.summary}\n`);
+  }
+}
+
+function createTarball(outDir: string): string {
+  const tarball = path.join(ROOT, "release-evidence-bundle.tar.gz");
+  if (fs.existsSync(tarball)) fs.unlinkSync(tarball);
+  const result = spawnSync("tar", ["-czf", tarball, "-C", outDir, "."], {
+    cwd: ROOT,
+    encoding: "utf-8",
+  });
+  if (result.status !== 0) {
+    console.warn("⚠️  Could not create tarball (tar failed). Directory bundle is still available.");
+    return "";
+  }
+  return tarball;
+}
+
+async function main(): Promise<void> {
+  const opts = parseArgs();
+
+  const outDir = path.isAbsolute(opts.output)
+    ? opts.output
+    : path.join(ROOT, opts.output);
+
+  if (fs.existsSync(outDir)) {
+    fs.rmSync(outDir, { recursive: true });
+  }
+  fs.mkdirSync(path.join(outDir, "checks"), { recursive: true });
+
+  console.log(`\n📦 Generating release evidence for wave: ${opts.wave}\n`);
+
+  const gitMeta = captureGitEvidence(outDir, opts.base);
+  const checkResults: CheckResult[] = [];
+
+  if (opts.skipChecks) {
+    console.log("⏭️  Skipping local checks (--skip-checks); packaging metadata only.\n");
+  } else {
+    for (const def of CHECKS) {
+      if (opts.quick && def.heavy) {
+        checkResults.push({
+          id: def.id,
+          name: def.name,
+          category: def.category,
+          status: "skip",
+          exitCode: null,
+          durationMs: 0,
+          reproCommand: def.repro,
+          summary: "Skipped (--quick)",
+          logFile: "",
+        });
+        console.log(`⏭️  ${def.name} (skipped — quick mode)`);
+        continue;
+      }
+
+      process.stdout.write(`▶ ${def.name}… `);
+      const result = runCheck(def, path.join(outDir, "checks"));
+      checkResults.push(result);
+      const icon = result.status === "pass" ? "✅" : result.status === "warn" ? "⚠️" : "❌";
+      console.log(`${icon} (${result.durationMs}ms)`);
+    }
+  }
+
+  const serviceHealth = await probeServiceHealth();
+  fs.writeFileSync(
+    path.join(outDir, "service-health.json"),
+    JSON.stringify(serviceHealth, null, 2),
+  );
+
+  const ciLayers = opts.layerResultsPath
+    ? loadLayerResults(opts.layerResultsPath)
+    : null;
+
+  if (ciLayers) {
+    const failed = Object.entries(ciLayers).filter(([, v]) => v === "failure");
+    if (failed.length) {
+      console.error("\n❌ CI reports failed layers:");
+      for (const [job, result] of failed) {
+        console.error(`  • ${job}: ${result}`);
+      }
+    }
+  }
+
+  const requiredFailed = checkResults.some((c) => c.status === "fail");
+  const ciFailed = ciLayers && Object.values(ciLayers).some((v) => v === "failure");
+
+  const manifest = {
+    schemaVersion: "1.0",
+    wave: opts.wave,
+    timestamp: new Date().toISOString(),
+    git: gitMeta,
+    ci: opts.github ?? null,
+    ciLayers,
+    checks: checkResults,
+    serviceHealth,
+    summary: {
+      ready: !requiredFailed && !ciFailed,
+      requiredChecksPassed: !requiredFailed,
+      ciLayersPassed: ciLayers ? !ciFailed : null,
+    },
+  };
+
+  fs.writeFileSync(path.join(outDir, "manifest.json"), JSON.stringify(manifest, null, 2));
+  writeHumanReport(outDir, manifest, checkResults);
+
+  const tarball = createTarball(outDir);
+  const relOut = path.relative(ROOT, outDir);
+
+  console.log(`\n✅ Evidence bundle written to ${relOut}/`);
+  if (tarball) {
+    console.log(`✅ Archive: ${path.relative(ROOT, tarball)}`);
+  }
+  console.log(`   • manifest.json — machine-readable summary`);
+  console.log(`   • EVIDENCE.md — auditor / maintainer report`);
+  console.log(`   • checks/*.log — full command output`);
+  console.log(`   • git/ — commit range and metadata`);
+  console.log(`   • service-health.json — health probe notes\n`);
+
+  printActionableFailures(checkResults);
+
+  if (requiredFailed || ciFailed) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("❌ generate-release-evidence failed:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
…readiness

Closes #360

## Summary

Adds an automated release evidence bundle that captures commit range, validation outputs, config checks, and service health notes for each wave-prep release candidate. Integrates with the existing Release Candidate workflow (DEVOPS-204).

### What changed

**Scripts**
- Add `scripts/generate-release-evidence.ts` — builds `release-evidence/` with `manifest.json`, `EVIDENCE.md`, check logs, git metadata, health probes, and `release-evidence-bundle.tar.gz`.
- Add `npm run release-evidence` in root `package.json`.

**CI**
- Extend `.github/workflows/release-candidate.yml` `rc-gate` to generate and upload the bundle after all layers pass.
- Document wave-prep → evidence flow in `.github/workflows/ci.yml`.

**Docs**
- Add `docs/release-evidence-bundle.md` — usage, checks matrix, failure interpretation, audit checklist.
- Update `docs/release-candidate.md` — link to evidence bundle artifacts.

**Repo hygiene**
- Ignore `release-evidence/` and `release-evidence-bundle.tar.gz` in `.gitignore` (generated artifacts, not source).


## Test plan

### Local

```bash
npm run release-evidence -- --wave wave-5 --quick
```

Expected: `release-evidence/` created; exit `0` if checks pass, `1` with actionable repro on failure.

### CI

Run **Release Candidate** workflow (manual dispatch or `release/**` push). On green `rc-gate`:

- Artifact `release-evidence-<run_id>` contains bundle + tarball
- Step summary includes `EVIDENCE.md`

```bash
gh workflow run release-candidate.yml --field wave_label=wave-5
gh run download <run_id> --name release-evidence-<run_id>
```

## Acceptance criteria

| Criterion | Status |
|-----------|--------|
| Automated and documented for repeat use | Script + `docs/release-evidence-bundle.md` + RC workflow |
| Failures produce actionable output | Console repro + `checks/*.log` + `EVIDENCE.md` |
| Integrates with monorepo CI | `release-candidate.yml` + `npm run release-evidence` |

## Notes

- Builds on **DEVOPS-204** Release Candidate workflow; does not replace layer jobs.
- Local runs may fail individual checks (drift, missing package dist) until the repo is in a clean state — that is expected; fix and re-run.

## Files changed

| File | Change |
|------|--------|
| `scripts/generate-release-evidence.ts` | Bundle generator |
| `package.json` | `release-evidence` script |
| `.github/workflows/release-candidate.yml` | Generate + upload bundle in `rc-gate` |
| `.github/workflows/ci.yml` | Cross-link in wave-prep comment |
| `docs/release-evidence-bundle.md` | Maintainer documentation |
| `docs/release-candidate.md` | Evidence artifact section |
| `.gitignore` | Ignore generated bundle paths |
