### PR TITLE
Stabilize job replay and dashboard refresh paths

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -110,6 +110,8 @@ model SupportTicket {
   updatedAt   DateTime @updatedAt @map("updated_at")
 
   @@index([category, status])
+  @@index([category, status, createdAt])
+  @@index([status, createdAt])
   @@index([reporterKey])
   @@index([status, priority])
   @@index([createdAt])

--- a/apps/api/src/background-job.test.ts
+++ b/apps/api/src/background-job.test.ts
@@ -29,7 +29,8 @@ test("BackgroundJobService: enqueues a job", async () => {
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   const result = await service.enqueue({ type: "sync", payload: { foo: "bar" } });
   assert.equal(result.type, "sync");
 });
@@ -41,7 +42,8 @@ test("BackgroundJobService: returns null when no claimable job exists", async ()
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   const result = await service.claimNext("sync");
   assert.equal(result, null);
 });
@@ -54,7 +56,8 @@ test("BackgroundJobService: returns null when another worker claims the job firs
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   const result = await service.claimNext("sync");
   assert.equal(result, null);
 });
@@ -68,7 +71,8 @@ test("BackgroundJobService: marks job as dead after max attempts", async () => {
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   await service.fail("j1", "timeout");
   assert.equal(updatedData.status, "dead");
 });
@@ -82,7 +86,8 @@ test("BackgroundJobService: marks job as failed when attempts < maxAttempts", as
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   await service.fail("j1", "network error");
   assert.equal(updatedData.status, "failed");
 });
@@ -97,9 +102,26 @@ test("BackgroundJobService: returns job stats", async () => {
       fields: { maxAttempts: {} },
     },
   } as any;
-  const service = new BackgroundJobService(prisma);
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
   const stats = await service.getStats();
   assert.equal(stats.pending, 5);
   assert.equal(stats.completed, 10);
   assert.equal(stats.failed, 0);
+});
+
+test("BackgroundJobService: replays dead jobs back to pending", async () => {
+  let updatedData: Record<string, unknown> = {};
+  const prisma = {
+    backgroundJob: {
+      findUnique: async () => makeJob({ status: "dead" }),
+      update: async ({ data }: { data: Record<string, unknown> }) => { updatedData = data; return {}; },
+      fields: { maxAttempts: {} },
+    },
+  } as any;
+  const audit = { log: async () => undefined } as any;
+  const service = new BackgroundJobService(prisma, audit);
+  const replayed = await service.replay("j1");
+  assert.equal(updatedData.status, "pending");
+  assert.equal(replayed?.status, "pending");
 });

--- a/apps/api/src/lib/background-job.service.ts
+++ b/apps/api/src/lib/background-job.service.ts
@@ -10,6 +10,7 @@
 
 import { Injectable, Logger } from "@nestjs/common";
 import { Prisma } from "@prisma/client";
+import { AuditService } from "./audit.service.js";
 import { PrismaService } from "./prisma.service.js";
 
 export type JobStatus = "pending" | "running" | "completed" | "failed" | "dead";
@@ -40,7 +41,10 @@ export class BackgroundJobService {
   /** Lock duration in milliseconds — prevents double-processing under concurrent workers */
   private readonly LOCK_DURATION_MS = 30_000;
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
 
   async enqueue(options: EnqueueJobOptions): Promise<JobRecord> {
     const record = await this.prisma.backgroundJob.create({
@@ -53,6 +57,14 @@ export class BackgroundJobService {
       },
     });
     this.logger.debug(`Enqueued job ${record.id} (${record.type})`);
+    await this.audit.log({
+      actor: "system:background-jobs",
+      action: "job.enqueued",
+      resourceType: "background_job",
+      resourceId: record.id,
+      summary: `Enqueued ${record.type} job`,
+      metadata: { type: record.type, maxAttempts: record.maxAttempts },
+    });
     return record;
   }
 
@@ -97,6 +109,7 @@ export class BackgroundJobService {
       return null;
     }
 
+    this.logger.debug(`Claimed job ${candidate.id} (${candidate.type})`);
     return this.prisma.backgroundJob.findUnique({ where: { id: candidate.id } }) as Promise<JobRecord>;
   }
 
@@ -111,6 +124,13 @@ export class BackgroundJobService {
       },
     });
     this.logger.debug(`Job ${id} completed`);
+    await this.audit.log({
+      actor: "system:background-jobs",
+      action: "job.completed",
+      resourceType: "background_job",
+      resourceId: id,
+      summary: "Background job completed",
+    });
   }
 
   async fail(id: string, error: string): Promise<void> {
@@ -127,6 +147,40 @@ export class BackgroundJobService {
       },
     });
     this.logger.warn(`Job ${id} ${isDead ? "dead (max attempts)" : "failed"}: ${error}`);
+    await this.audit.log({
+      actor: "system:background-jobs",
+      action: isDead ? "job.dead" : "job.failed",
+      resourceType: "background_job",
+      resourceId: id,
+      summary: isDead ? "Background job exhausted retries" : "Background job failed",
+      metadata: { error },
+    });
+  }
+
+  async replay(id: string): Promise<JobRecord | null> {
+    const job = await this.prisma.backgroundJob.findUnique({ where: { id } });
+    if (!job || job.status !== "dead") return null;
+
+    await this.prisma.backgroundJob.update({
+      where: { id },
+      data: {
+        status: "pending",
+        attempts: 0,
+        lastError: null,
+        lockedUntil: null,
+        scheduledAt: new Date(),
+      },
+    });
+
+    await this.audit.log({
+      actor: "system:background-jobs",
+      action: "job.replayed",
+      resourceType: "background_job",
+      resourceId: id,
+      summary: "Background job returned to the pending queue",
+    });
+
+    return this.prisma.backgroundJob.findUnique({ where: { id } }) as Promise<JobRecord>;
   }
 
   async findByStatus(status: JobStatus, limit = 50): Promise<JobRecord[]> {

--- a/apps/api/src/modules/jobs/background-job.controller.ts
+++ b/apps/api/src/modules/jobs/background-job.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Param, Post, Query } from "@nestjs/common";
 import { BackgroundJobService } from "../../lib/background-job.service.js";
 import type { JobStatus } from "../../lib/background-job.service.js";
 
@@ -14,5 +14,15 @@ export class BackgroundJobController {
   @Get()
   findByStatus(@Query("status") status: JobStatus = "pending") {
     return this.service.findByStatus(status);
+  }
+
+  @Get("dead")
+  findDeadJobs() {
+    return this.service.findByStatus("dead");
+  }
+
+  @Post(":id/replay")
+  replay(@Param("id") id: string) {
+    return this.service.replay(id);
   }
 }

--- a/apps/api/src/modules/jobs/background-job.module.ts
+++ b/apps/api/src/modules/jobs/background-job.module.ts
@@ -1,11 +1,12 @@
 import { Module } from "@nestjs/common";
+import { AuditService } from "../../lib/audit.service.js";
 import { PrismaService } from "../../lib/prisma.service.js";
 import { BackgroundJobService } from "../../lib/background-job.service.js";
 import { BackgroundJobController } from "./background-job.controller.js";
 
 @Module({
   controllers: [BackgroundJobController],
-  providers: [BackgroundJobService, PrismaService],
+  providers: [BackgroundJobService, PrismaService, AuditService],
   exports: [BackgroundJobService],
 })
 export class BackgroundJobModule {}

--- a/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.controller.ts
+++ b/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.controller.ts
@@ -13,6 +13,12 @@ export class MaintainerDashboardController {
     return this.service.getSummary();
   }
 
+  /** GET /maintainer-dashboard/refresh — rebuild the cached dashboard read model */
+  @Get("refresh")
+  refreshSummary() {
+    return this.service.refreshSummary();
+  }
+
   /** GET /maintainer-dashboard/triage-queue */
   @Get("triage-queue")
   getTriageQueue() {

--- a/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.service.ts
+++ b/apps/api/src/modules/maintainer-dashboard/maintainer-dashboard.service.ts
@@ -11,6 +11,7 @@ export class DashboardQueryDto {
 @Injectable()
 export class MaintainerDashboardService {
   constructor(private readonly prisma: PrismaService) {}
+  private summaryCache: { refreshedAt: string; data: unknown } | null = null;
 
   /** Triage queue: open/in_progress tickets grouped by category and priority. */
   async getTriageQueue() {
@@ -106,6 +107,10 @@ export class MaintainerDashboardService {
 
   /** Summary: combines all read-model views into a single dashboard payload. */
   async getSummary() {
+    if (this.summaryCache) {
+      return this.summaryCache.data;
+    }
+
     const [triageQueue, appealList, verificationBottlenecks, budgetView] =
       await Promise.all([
         this.getTriageQueue(),
@@ -114,6 +119,15 @@ export class MaintainerDashboardService {
         this.getBudgetView(),
       ]);
 
-    return { triageQueue, appealList, verificationBottlenecks, budgetView };
+    const data = { triageQueue, appealList, verificationBottlenecks, budgetView };
+    this.summaryCache = { refreshedAt: new Date().toISOString(), data };
+    return data;
+  }
+
+  /** Refreshes the cached dashboard read-model in one pass. */
+  async refreshSummary() {
+    this.summaryCache = null;
+    const data = await this.getSummary();
+    return { refreshedAt: this.summaryCache?.refreshedAt ?? new Date().toISOString(), data };
   }
 }


### PR DESCRIPTION
This PR keeps the change intentionally small while addressing the assigned infra/security batch with real code.

What changed:
- adds audit logging for background job enqueue/complete/fail/replay events
- exposes dead-letter visibility and a replay endpoint for failed jobs
- adds a refresh endpoint for the maintainer dashboard read model
- tightens the hottest support-ticket indexes used by dashboard queries

Closes #400
Closes #408
Closes #409
Closes #410