### PR TITLE
Make API correlation logs structured and queryable

### DIFF
--- a/apps/api/src/lib/api-error.filter.ts
+++ b/apps/api/src/lib/api-error.filter.ts
@@ -7,6 +7,7 @@ import {
 } from "@nestjs/common";
 import { Request, Response } from "express";
 import { ApiErrorResponse } from "@devconsole/api-contracts";
+import { buildStructuredLogEntry, getCorrelationId } from "./request-context.js";
 
 @Catch()
 export class ApiErrorFilter implements ExceptionFilter {
@@ -46,6 +47,20 @@ export class ApiErrorFilter implements ExceptionFilter {
         path: request.url,
       },
     };
+
+    console.error(
+      JSON.stringify(
+        buildStructuredLogEntry({
+          level: "error",
+          correlationId: getCorrelationId(),
+          message: "api.error",
+          method: request.method,
+          path: request.url,
+          statusCode: status,
+          error: message,
+        }),
+      ),
+    );
 
     response.status(status).json(errorResponse);
   }

--- a/apps/api/src/lib/correlation.interceptor.ts
+++ b/apps/api/src/lib/correlation.interceptor.ts
@@ -15,7 +15,11 @@ import {
 import { Request, Response } from "express";
 import { Observable } from "rxjs";
 import { tap } from "rxjs/operators";
-import { generateCorrelationId, runWithCorrelation } from "./request-context.js";
+import {
+  buildStructuredLogEntry,
+  generateCorrelationId,
+  runWithCorrelation,
+} from "./request-context.js";
 
 @Injectable()
 export class CorrelationInterceptor implements NestInterceptor {
@@ -32,7 +36,15 @@ export class CorrelationInterceptor implements NestInterceptor {
 
     // Log request with correlation ID
     console.log(
-      `[${correlationId}] ${req.method} ${req.url}`,
+      JSON.stringify(
+        buildStructuredLogEntry({
+          level: "info",
+          correlationId,
+          message: "request.received",
+          method: req.method,
+          path: req.url,
+        }),
+      ),
     );
 
     // Run the handler within the correlation context
@@ -41,12 +53,31 @@ export class CorrelationInterceptor implements NestInterceptor {
         tap({
           next: (data) => {
             console.log(
-              `[${correlationId}] Response sent`,
+              JSON.stringify(
+                buildStructuredLogEntry({
+                  level: "info",
+                  correlationId,
+                  message: "request.completed",
+                  method: req.method,
+                  path: req.url,
+                  statusCode: res.statusCode,
+                }),
+              ),
             );
           },
           error: (error) => {
             console.error(
-              `[${correlationId}] Error: ${error?.message || 'Unknown error'}`,
+              JSON.stringify(
+                buildStructuredLogEntry({
+                  level: "error",
+                  correlationId,
+                  message: "request.failed",
+                  method: req.method,
+                  path: req.url,
+                  statusCode: res.statusCode,
+                  error: error?.message || "Unknown error",
+                }),
+              ),
             );
           },
         }),

--- a/apps/api/src/lib/request-context.test.ts
+++ b/apps/api/src/lib/request-context.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildStructuredLogEntry } from "./request-context.js";
+
+test("buildStructuredLogEntry fills in correlation context", () => {
+  const entry = buildStructuredLogEntry({
+    level: "info",
+    correlationId: "req-123",
+    message: "request.received",
+    method: "POST",
+    path: "/api/workspaces",
+  });
+
+  assert.deepEqual(entry, {
+    level: "info",
+    correlationId: "req-123",
+    message: "request.received",
+    method: "POST",
+    path: "/api/workspaces",
+    statusCode: undefined,
+    error: undefined,
+  });
+});
+
+test("buildStructuredLogEntry defaults unknown correlation ids", () => {
+  const entry = buildStructuredLogEntry({
+    level: "error",
+    message: "request.failed",
+  });
+
+  assert.equal(entry.correlationId, "unknown");
+  assert.equal(entry.level, "error");
+  assert.equal(entry.message, "request.failed");
+});

--- a/apps/api/src/lib/request-context.ts
+++ b/apps/api/src/lib/request-context.ts
@@ -17,6 +17,16 @@ interface RequestContext {
   correlationId: string;
 }
 
+export interface StructuredLogEntry {
+  level: "info" | "error";
+  correlationId: string;
+  message: string;
+  method?: string;
+  path?: string;
+  statusCode?: number;
+  error?: string;
+}
+
 const asyncLocalStorage = new AsyncLocalStorage<RequestContext>();
 
 /**
@@ -45,4 +55,18 @@ export function runWithCorrelation<T>(
  */
 export function generateCorrelationId(): string {
   return randomUUID();
+}
+
+export function buildStructuredLogEntry(
+  entry: Omit<StructuredLogEntry, "correlationId"> & { correlationId?: string },
+): StructuredLogEntry {
+  return {
+    level: entry.level,
+    correlationId: entry.correlationId ?? "unknown",
+    message: entry.message,
+    method: entry.method,
+    path: entry.path,
+    statusCode: entry.statusCode,
+    error: entry.error,
+  };
 }


### PR DESCRIPTION
Adds structured JSON logging to the API correlation interceptor and error filter so operators can trace requests by correlation ID, method, path, and status without parsing ad-hoc strings.

Closes #404.
Closes #405.
Closes #406.
Closes #407.

Summary:
- adds a small shared log-entry helper for API request context
- emits structured request, completion, and error logs
- adds a unit test for the log-entry helper