### PR TITLE
feat(ai-208): run new AI review logic in shadow mode before broad rollout

### DIFF
--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
@@ -4,10 +4,11 @@ import { AuditService } from "../../lib/audit.service.js";
 import { AppealDecisionsController } from "./appeal-decisions.controller.js";
 import { AppealDecisionsService } from "./appeal-decisions.service.js";
 import { AppealDecisionsRepository } from "./appeal-decisions.repository.js";
+import { ShadowModeService } from "./shadow-mode.service.js";
 
 @Module({
   controllers: [AppealDecisionsController],
-  providers: [AppealDecisionsService, AppealDecisionsRepository, PrismaService, AuditService],
-  exports: [AppealDecisionsService],
+  providers: [AppealDecisionsService, AppealDecisionsRepository, PrismaService, AuditService, ShadowModeService],
+  exports: [AppealDecisionsService, ShadowModeService],
 })
 export class AppealDecisionsModule {}

--- a/apps/api/src/modules/appeal-decisions/shadow-mode.service.spec.ts
+++ b/apps/api/src/modules/appeal-decisions/shadow-mode.service.spec.ts
@@ -1,0 +1,67 @@
+import { ShadowModeService } from "./shadow-mode.service.js";
+
+const BASE_REQUEST = {
+  appealId: "appeal-1",
+  contributorId: "contrib-1",
+  issueRef: "issue-42",
+  features: { commentCount: 3 },
+};
+
+describe("ShadowModeService", () => {
+  let svc: ShadowModeService;
+
+  beforeEach(() => {
+    svc = new ShadowModeService();
+  });
+
+  it("returns a result without divergence when bands match", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.85 },
+      async () => 0.9,
+    );
+    expect(result).not.toBeNull();
+    expect(result!.diverged).toBe(false);
+    expect(result!.delta).toBeCloseTo(0.05);
+  });
+
+  it("flags divergence when bands differ", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.85 },
+      async () => 0.5, // live=approve, candidate=review
+    );
+    expect(result!.diverged).toBe(true);
+  });
+
+  it("returns null (without throwing) when the candidate scorer throws", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.5 },
+      async () => { throw new Error("model unavailable"); },
+    );
+    expect(result).toBeNull();
+  });
+
+  it("clamps candidate score to [0, 1]", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.5 },
+      async () => 5.0,
+    );
+    expect(result!.candidateScore).toBe(1);
+  });
+
+  it("records latencyMs and scoredAt", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.5 },
+      async () => 0.5,
+    );
+    expect(result!.latencyMs).toBeGreaterThanOrEqual(0);
+    expect(result!.scoredAt).toMatch(/^\d{4}-/);
+  });
+
+  it("accepts synchronous scorers", async () => {
+    const result = await svc.scoreShadow(
+      { ...BASE_REQUEST, liveScore: 0.5 },
+      () => 0.5,
+    );
+    expect(result).not.toBeNull();
+  });
+});

--- a/apps/api/src/modules/appeal-decisions/shadow-mode.service.ts
+++ b/apps/api/src/modules/appeal-decisions/shadow-mode.service.ts
@@ -1,0 +1,115 @@
+/**
+ * AI-208: Shadow-mode scoring for AI appeal review logic.
+ *
+ * Runs candidate model logic against live-like appeal traffic without
+ * producing any side-effects (no DB writes, no notifications, no state changes).
+ * Results are logged so they can be compared against the live model's decisions
+ * to judge a candidate safely before promotion.
+ *
+ * Explicit inputs  → scoreShadow(request, scorerFn)
+ * Explicit outputs → ShadowScoreResult (score, band, diverged, latencyMs)
+ * Review boundary  → ShadowScoreResult.diverged=true surfaces cases where the
+ *                    candidate disagrees with the live model; humans inspect these.
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+
+export interface ShadowScoreRequest {
+  appealId: string;
+  contributorId: string;
+  issueRef: string;
+  /** Raw score produced by the currently-live model (0–1). */
+  liveScore: number;
+  /** Any additional feature payload the candidate model needs. */
+  features: Record<string, unknown>;
+}
+
+export interface ShadowScoreResult {
+  appealId: string;
+  /** Score produced by the candidate model (0–1). */
+  candidateScore: number;
+  /** Score produced by the live model for comparison. */
+  liveScore: number;
+  /** True when the two scores fall into different policy bands. */
+  diverged: boolean;
+  /** Absolute difference between candidate and live scores. */
+  delta: number;
+  latencyMs: number;
+  scoredAt: string;
+}
+
+/** A scorer function signature — the candidate logic to evaluate in shadow. */
+export type CandidateScorerFn = (
+  features: Record<string, unknown>,
+) => number | Promise<number>;
+
+/** Band boundaries used to detect meaningful divergence (mirrors calibration defaults). */
+const APPROVE_THRESHOLD = 0.8;
+const REJECT_THRESHOLD = 0.25;
+
+function toBand(score: number): "approve" | "review" | "reject" {
+  if (score >= APPROVE_THRESHOLD) return "approve";
+  if (score <= REJECT_THRESHOLD) return "reject";
+  return "review";
+}
+
+@Injectable()
+export class ShadowModeService {
+  private readonly logger = new Logger(ShadowModeService.name);
+
+  /**
+   * Run the candidate scorer in shadow mode.
+   * Never throws — errors in the candidate are caught and logged so the live
+   * path is never disrupted.
+   *
+   * @returns ShadowScoreResult, or null if the candidate itself errored.
+   */
+  async scoreShadow(
+    request: ShadowScoreRequest,
+    candidateScorer: CandidateScorerFn,
+  ): Promise<ShadowScoreResult | null> {
+    const start = Date.now();
+
+    let candidateScore: number;
+    try {
+      candidateScore = await Promise.resolve(candidateScorer(request.features));
+      // Clamp to [0, 1]
+      candidateScore = Math.min(1, Math.max(0, candidateScore));
+    } catch (err) {
+      this.logger.warn(
+        `shadow-mode scorer error for appeal ${request.appealId}: ${(err as Error).message}`,
+      );
+      return null;
+    }
+
+    const latencyMs = Date.now() - start;
+    const delta = Math.abs(candidateScore - request.liveScore);
+    const diverged = toBand(candidateScore) !== toBand(request.liveScore);
+
+    const result: ShadowScoreResult = {
+      appealId: request.appealId,
+      candidateScore,
+      liveScore: request.liveScore,
+      diverged,
+      delta,
+      latencyMs,
+      scoredAt: new Date().toISOString(),
+    };
+
+    // Emit as a structured log line for offline analysis / metric pipelines.
+    this.logger.log(
+      JSON.stringify({
+        event: "shadow_score",
+        ...result,
+      }),
+    );
+
+    if (diverged) {
+      this.logger.warn(
+        `shadow divergence on appeal ${request.appealId}: live=${request.liveScore.toFixed(3)} candidate=${candidateScore.toFixed(3)}`,
+      );
+    }
+
+    return result;
+  }
+}

--- a/docs/ai-208-shadow-mode.md
+++ b/docs/ai-208-shadow-mode.md
@@ -1,0 +1,54 @@
+# AI-208: Shadow Mode for AI Appeal Review Logic
+
+## Overview
+
+`ShadowModeService` provides a safe path for evaluating candidate model changes
+against live-like appeal traffic without affecting any outcomes. The candidate
+scorer runs in a fire-and-observe loop: results are logged, never acted on.
+
+## How it works
+
+```
+live appeal request
+      │
+      ├─► live scorer  ─► outcome applied (DB write, notification, etc.)
+      │
+      └─► ShadowModeService.scoreShadow(request, candidateScorer)
+                │
+                ├─► candidate scorer runs (errors caught; live path unaffected)
+                ├─► result logged as structured JSON  { event: "shadow_score", … }
+                └─► diverged=true logged as WARN if bands differ
+```
+
+## Explicit Inputs / Outputs
+
+| Direction | What it is |
+|-----------|-----------|
+| **Input** | `ShadowScoreRequest.liveScore` — current model's score |
+| **Input** | `ShadowScoreRequest.features` — feature payload forwarded to candidate |
+| **Input** | `candidateScorer: CandidateScorerFn` — the new logic under test |
+| **Output** | `ShadowScoreResult.candidateScore` — what the candidate would have scored |
+| **Output** | `ShadowScoreResult.diverged` — true when bands differ (human review signal) |
+| **Output** | `ShadowScoreResult.delta` — magnitude of score difference |
+
+## Review Boundary
+
+`diverged=true` means the candidate places the appeal in a different policy band
+than the live model. These cases must be inspected by a maintainer before the
+candidate is promoted.
+
+**The shadow path never writes to the database, sends notifications, or changes
+appeal state.** It is safe to run on any live traffic.
+
+## Promotion Checklist
+
+Before promoting a candidate to production:
+
+1. Run shadow mode for ≥ 48 hours of live traffic.
+2. Review all `diverged=true` log lines — confirm the candidate's band is correct.
+3. Check P95 `latencyMs` is acceptable.
+4. Record findings as a comment on the AI-208 issue before merging.
+
+## File Location
+
+`apps/api/src/modules/appeal-decisions/shadow-mode.service.ts`


### PR DESCRIPTION
## Summary

Creates a shadow-mode path that scores live-like appeal traffic without affecting any outcomes, so model changes can be evaluated safely before promotion.

## Changes

- `ShadowModeService` in `appeal-decisions` module
  - Runs candidate scorer with zero side-effects (no DB writes, no notifications, no state changes)
  - Catches all candidate errors — live path is never disrupted
  - `diverged=true` when candidate and live model fall in different policy bands
  - Structured `shadow_score` log lines for offline metric pipelines
- Operator promotion checklist in `docs/ai-208-shadow-mode.md`

## Acceptance Criteria

- [x] Explicit inputs (`liveScore`, `features`, `candidateScorer`) and outputs (`diverged`, `delta`, `latencyMs`) — no hidden heuristics
- [x] `diverged` and `latencyMs` are measurable signals for promotion decisions
- [x] Human review required for all `diverged=true` cases before promotion

Closes #425