### PR TITLE
feat(ai-209): add model rollback and safe rollout controls for appeal automation

### DIFF
--- a/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
+++ b/apps/api/src/modules/appeal-decisions/appeal-decisions.module.ts
@@ -4,10 +4,11 @@ import { AuditService } from "../../lib/audit.service.js";
 import { AppealDecisionsController } from "./appeal-decisions.controller.js";
 import { AppealDecisionsService } from "./appeal-decisions.service.js";
 import { AppealDecisionsRepository } from "./appeal-decisions.repository.js";
+import { ModelRolloutService } from "./model-rollout.service.js";
 
 @Module({
   controllers: [AppealDecisionsController],
-  providers: [AppealDecisionsService, AppealDecisionsRepository, PrismaService, AuditService],
-  exports: [AppealDecisionsService],
+  providers: [AppealDecisionsService, AppealDecisionsRepository, PrismaService, AuditService, ModelRolloutService],
+  exports: [AppealDecisionsService, ModelRolloutService],
 })
 export class AppealDecisionsModule {}

--- a/apps/api/src/modules/appeal-decisions/model-rollout.service.spec.ts
+++ b/apps/api/src/modules/appeal-decisions/model-rollout.service.spec.ts
@@ -1,0 +1,82 @@
+import { ModelRolloutService } from "./model-rollout.service.js";
+
+describe("ModelRolloutService", () => {
+  let svc: ModelRolloutService;
+
+  beforeEach(() => {
+    svc = new ModelRolloutService();
+  });
+
+  describe("pinned mode", () => {
+    it("always routes to stableVersion", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "pinned" });
+      const r = svc.resolveModel("any-request-id");
+      expect(r.modelVersion).toBe("v1");
+      expect(r.mode).toBe("pinned");
+    });
+  });
+
+  describe("full mode", () => {
+    it("always routes to activeVersion", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "full" });
+      const r = svc.resolveModel("any-request-id");
+      expect(r.modelVersion).toBe("v2");
+    });
+  });
+
+  describe("canary mode", () => {
+    it("routes 0% canary to stable every time", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "canary", canaryPercent: 0 });
+      for (let i = 0; i < 20; i++) {
+        expect(svc.resolveModel(`id-${i}`).modelVersion).toBe("v1");
+      }
+    });
+
+    it("routes 100% canary to active every time", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "canary", canaryPercent: 100 });
+      for (let i = 0; i < 20; i++) {
+        expect(svc.resolveModel(`id-${i}`).modelVersion).toBe("v2");
+      }
+    });
+
+    it("is deterministic — same requestId yields same routing", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "canary", canaryPercent: 50 });
+      const first = svc.resolveModel("stable-request-id");
+      const second = svc.resolveModel("stable-request-id");
+      expect(first.modelVersion).toBe(second.modelVersion);
+    });
+  });
+
+  describe("rollback", () => {
+    it("restores the previous config", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "full" });
+      svc.rollback();
+      const r = svc.resolveModel("x");
+      // should be back to default (pinned to v1)
+      expect(r.modelVersion).toBe("v1");
+      expect(r.mode).toBe("pinned");
+    });
+
+    it("is a no-op when there is no previous config", () => {
+      const before = svc.getState();
+      svc.rollback();
+      const after = svc.getState();
+      expect(after.current).toEqual(before.current);
+    });
+
+    it("clears previous after rollback (single-level undo)", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "full" });
+      svc.rollback();
+      expect(svc.getState().previous).toBeNull();
+    });
+  });
+
+  describe("getState", () => {
+    it("exposes current and previous configs", () => {
+      svc.setRollout({ activeVersion: "v2", stableVersion: "v1", mode: "full" });
+      const state = svc.getState();
+      expect(state.current.mode).toBe("full");
+      expect(state.previous!.mode).toBe("pinned");
+    });
+  });
+});

--- a/apps/api/src/modules/appeal-decisions/model-rollout.service.ts
+++ b/apps/api/src/modules/appeal-decisions/model-rollout.service.ts
@@ -1,0 +1,164 @@
+/**
+ * AI-209: Model rollback and safe rollout controls for appeal automation.
+ *
+ * Provides guarded rollout modes (pinned, canary, full) so AI behaviour can be
+ * promoted incrementally and rolled back instantly if fairness or quality metrics
+ * drift. All transitions are explicit, logged, and reversible.
+ *
+ * Explicit inputs  → setRollout(config) / resolveModel(context)
+ * Explicit outputs → RolloutResolution (modelVersion, mode, reason)
+ * Review boundary  → canary mode routes only the configured % of traffic to the
+ *                    candidate; humans monitor before promoting to "full"
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+
+export type RolloutMode = "pinned" | "canary" | "full";
+
+export interface RolloutConfig {
+  /** The model version to use in "pinned" and "full" modes, and as canary candidate. */
+  activeVersion: string;
+  /** The stable fallback version used when not in "full" mode or when canary misses. */
+  stableVersion: string;
+  mode: RolloutMode;
+  /**
+   * In "canary" mode: percentage of requests routed to activeVersion (0–100).
+   * Ignored in other modes.
+   */
+  canaryPercent?: number;
+}
+
+export interface RolloutResolution {
+  modelVersion: string;
+  mode: RolloutMode;
+  /** Human-readable reason for the routing decision (for logs / operator inspection). */
+  reason: string;
+}
+
+export interface ModelRolloutState {
+  current: RolloutConfig;
+  previous: RolloutConfig | null;
+  updatedAt: string;
+}
+
+const DEFAULT_CONFIG: RolloutConfig = {
+  activeVersion: "v1",
+  stableVersion: "v1",
+  mode: "pinned",
+  canaryPercent: 0,
+};
+
+@Injectable()
+export class ModelRolloutService {
+  private readonly logger = new Logger(ModelRolloutService.name);
+
+  private state: ModelRolloutState = {
+    current: { ...DEFAULT_CONFIG },
+    previous: null,
+    updatedAt: new Date().toISOString(),
+  };
+
+  /** Inspect the current rollout state (for operator dashboards / runbooks). */
+  getState(): ModelRolloutState {
+    return { ...this.state };
+  }
+
+  /**
+   * Update the rollout configuration.
+   * The previous config is preserved so rollback() can restore it instantly.
+   */
+  setRollout(config: RolloutConfig): ModelRolloutState {
+    const previous = this.state.current;
+    this.state = { current: config, previous, updatedAt: new Date().toISOString() };
+
+    this.logger.log(
+      JSON.stringify({
+        event: "rollout_config_updated",
+        mode: config.mode,
+        activeVersion: config.activeVersion,
+        stableVersion: config.stableVersion,
+        canaryPercent: config.canaryPercent ?? 0,
+      }),
+    );
+
+    return this.getState();
+  }
+
+  /**
+   * Roll back to the previous configuration immediately.
+   * No-op if there is no previous config (already at stable baseline).
+   */
+  rollback(): ModelRolloutState {
+    if (!this.state.previous) {
+      this.logger.warn("rollback requested but no previous config exists — no-op");
+      return this.getState();
+    }
+
+    const restored = this.state.previous;
+    this.state = {
+      current: restored,
+      previous: null,
+      updatedAt: new Date().toISOString(),
+    };
+
+    this.logger.warn(
+      JSON.stringify({
+        event: "rollout_rolled_back",
+        restoredVersion: restored.activeVersion,
+        restoredMode: restored.mode,
+      }),
+    );
+
+    return this.getState();
+  }
+
+  /**
+   * Resolve which model version to use for a given request context.
+   *
+   * @param requestId  Used as entropy source for canary bucketing (deterministic per request).
+   */
+  resolveModel(requestId: string): RolloutResolution {
+    const { mode, activeVersion, stableVersion, canaryPercent = 0 } = this.state.current;
+
+    if (mode === "pinned") {
+      return {
+        modelVersion: stableVersion,
+        mode,
+        reason: `pinned to stable version ${stableVersion}`,
+      };
+    }
+
+    if (mode === "full") {
+      return {
+        modelVersion: activeVersion,
+        mode,
+        reason: `full rollout of ${activeVersion}`,
+      };
+    }
+
+    // canary — deterministic bucketing via simple hash of requestId
+    const bucket = this.hashBucket(requestId, 100);
+    if (bucket < canaryPercent) {
+      return {
+        modelVersion: activeVersion,
+        mode,
+        reason: `canary bucket ${bucket} < ${canaryPercent}% → candidate ${activeVersion}`,
+      };
+    }
+
+    return {
+      modelVersion: stableVersion,
+      mode,
+      reason: `canary bucket ${bucket} ≥ ${canaryPercent}% → stable ${stableVersion}`,
+    };
+  }
+
+  /** Deterministic integer bucket [0, modulus) derived from a string. */
+  private hashBucket(input: string, modulus: number): number {
+    let hash = 0;
+    for (let i = 0; i < input.length; i++) {
+      hash = (hash * 31 + input.charCodeAt(i)) >>> 0;
+    }
+    return hash % modulus;
+  }
+}

--- a/docs/ai-209-rollout-controls.md
+++ b/docs/ai-209-rollout-controls.md
@@ -1,0 +1,53 @@
+# AI-209: Model Rollback and Safe Rollout Controls for Appeal Automation
+
+## Overview
+
+`ModelRolloutService` provides a lightweight, in-process rollout controller with
+three operating modes. AI behaviour can be pinned at a stable version, promoted
+to full traffic, or gradually canary'd — and rolled back in one API call.
+
+## Rollout Modes
+
+| Mode | Behaviour |
+|------|-----------|
+| `pinned` | All requests use `stableVersion`. Safe baseline; no candidate exposure. |
+| `canary` | `canaryPercent`% of requests use `activeVersion`; rest use `stableVersion`. Deterministic per `requestId`. |
+| `full` | All requests use `activeVersion`. Only after canary validation. |
+
+## Rollback
+
+```
+modelRolloutService.rollback()
+```
+
+Restores the previous `RolloutConfig` instantly. The service stores exactly one
+level of previous config so a single call always undoes the last `setRollout`.
+Rollback is a no-op if there is no previous config.
+
+## Explicit Inputs / Outputs
+
+| Direction | What it is |
+|-----------|-----------|
+| **Input** | `setRollout(config: RolloutConfig)` — operator sets mode, versions, canary% |
+| **Input** | `resolveModel(requestId)` — per-request routing decision |
+| **Output** | `RolloutResolution.modelVersion` — which version to use |
+| **Output** | `RolloutResolution.reason` — human-readable routing explanation |
+| **Output** | `ModelRolloutState` — current + previous config with timestamp |
+
+## Review Boundary
+
+Canary mode is the human review gate. Promote from `canary` → `full` only after:
+
+1. Reviewing divergence logs from `ShadowModeService` (AI-208).
+2. Confirming fairness metrics are stable.
+3. No increase in human override rate (from `AppealDecisionsService.humanOverride` flag).
+
+## Measurability
+
+Every `setRollout` and `rollback` emits a structured log event
+(`rollout_config_updated`, `rollout_rolled_back`) for metric pipelines and
+operator audit.
+
+## File Location
+
+`apps/api/src/modules/appeal-decisions/model-rollout.service.ts`

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -403,6 +403,48 @@ export interface AppealTimingResult {
   appealDeadline: string;
 }
 
+// ── AI-206: Policy-aware score calibration ────────────────────────────────────
+
+export type PolicyBand = "auto_approve" | "review" | "auto_reject";
+
+export interface CalibrationPolicy {
+  approveThreshold: number;
+  rejectThreshold: number;
+  humanReviewThreshold: number;
+  biasCorrectionFactor?: number;
+}
+
+export interface CalibratedScoreResponse {
+  band: PolicyBand;
+  action: "approve" | "escalate" | "reject";
+  confidence: number;
+  needsHumanReview: boolean;
+  rawScore: number;
+}
+
+// ── AI-209: Model rollout controls ────────────────────────────────────────────
+
+export type RolloutMode = "pinned" | "canary" | "full";
+
+export interface RolloutConfig {
+  activeVersion: string;
+  stableVersion: string;
+  mode: RolloutMode;
+  canaryPercent?: number;
+}
+
+export interface RolloutResolution {
+  modelVersion: string;
+  mode: RolloutMode;
+  reason: string;
+}
+
+export interface ModelRolloutState {
+  current: RolloutConfig;
+  previous: RolloutConfig | null;
+  updatedAt: string;
+}
+
 // ── Budget Accounting (BE-201, BE-202, BE-203, BE-204) ───────────────────────────
 
 export type BudgetEventType = 


### PR DESCRIPTION
## Summary

Introduces guarded rollout modes (pinned → canary → full) so AI behaviour can be promoted incrementally and rolled back instantly if fairness or quality metrics drift.

## Changes

- `ModelRolloutService` in `appeal-decisions` module
  - Three modes: `pinned` (stable only), `canary` (% split, deterministic per requestId), `full` (all traffic)
  - `rollback()` restores the previous `RolloutConfig` in one call
  - Structured `rollout_config_updated` / `rollout_rolled_back` log events
- `RolloutConfig`, `RolloutResolution`, `ModelRolloutState` types in `@devconsole/api-contracts`
- Operator runbook in `docs/ai-209-rollout-controls.md`

## Acceptance Criteria

- [x] Explicit inputs/outputs, no hidden routing
- [x] `canaryPercent` and mode are measurable and tunable at runtime
- [x] Single-call `rollback()` with preserved previous config for immediate operator override

Closes #426