### PR TITLE
feat(ai-210): detect coordinated abuse patterns across contributors, issues, and appeals

### DIFF
--- a/apps/api/src/modules/wave/coordinated-abuse-detection.service.spec.ts
+++ b/apps/api/src/modules/wave/coordinated-abuse-detection.service.spec.ts
@@ -1,0 +1,101 @@
+import {
+  CoordinatedAbuseDetectionService,
+  AbuseEvent,
+} from "./coordinated-abuse-detection.service.js";
+
+const now = new Date().toISOString();
+
+function makeEvent(
+  contributorId: string,
+  issueRef: string,
+  kind: AbuseEvent["kind"] = "appeal_submitted",
+  metadata?: Record<string, unknown>,
+): AbuseEvent {
+  return { contributorId, issueRef, kind, occurredAt: now, metadata };
+}
+
+describe("CoordinatedAbuseDetectionService", () => {
+  let svc: CoordinatedAbuseDetectionService;
+
+  beforeEach(() => {
+    svc = new CoordinatedAbuseDetectionService();
+  });
+
+  it("returns low risk and empty patterns for clean events", () => {
+    const events = [makeEvent("c1", "issue-1"), makeEvent("c2", "issue-2")];
+    const report = svc.analyse(events);
+    expect(report.overallRisk).toBe("low");
+    expect(report.patterns).toHaveLength(0);
+    expect(report.requiresHumanReview).toBe(false);
+  });
+
+  describe("VELOCITY_CLUSTER", () => {
+    it("fires when a contributor exceeds the event velocity limit", () => {
+      const events = Array.from({ length: 11 }, (_, i) =>
+        makeEvent("spammer", `issue-${i}`, "issue_claimed"),
+      );
+      const report = svc.analyse(events, { velocityEventLimit: 10 });
+      const p = report.patterns.find((x) => x.kind === "VELOCITY_CLUSTER");
+      expect(p).toBeDefined();
+      expect(p!.contributorIds).toContain("spammer");
+      expect(report.requiresHumanReview).toBe(true);
+    });
+  });
+
+  describe("APPEAL_FLOODING", () => {
+    it("fires when a contributor submits too many appeals", () => {
+      const events = Array.from({ length: 6 }, (_, i) =>
+        makeEvent("flooder", `issue-${i}`, "appeal_submitted"),
+      );
+      const report = svc.analyse(events, { appealFloodLimit: 5 });
+      const p = report.patterns.find((x) => x.kind === "APPEAL_FLOODING");
+      expect(p).toBeDefined();
+      expect(report.requiresHumanReview).toBe(true);
+    });
+  });
+
+  describe("ISSUE_FARMING", () => {
+    it("fires when too many contributors claim the same issue", () => {
+      const events = ["c1", "c2", "c3", "c4"].map((c) =>
+        makeEvent(c, "hot-issue", "issue_claimed"),
+      );
+      const report = svc.analyse(events, { issueFarmingContributorLimit: 4 });
+      const p = report.patterns.find((x) => x.kind === "ISSUE_FARMING");
+      expect(p).toBeDefined();
+      expect(p!.issueRefs).toContain("hot-issue");
+    });
+  });
+
+  describe("SHARED_METADATA", () => {
+    it("fires when 3+ contributors share the same metadata value", () => {
+      const events = ["c1", "c2", "c3"].map((c) =>
+        makeEvent(c, `issue-${c}`, "contributor_registered", { ipHash: "abc123" }),
+      );
+      const report = svc.analyse(events);
+      const p = report.patterns.find((x) => x.kind === "SHARED_METADATA");
+      expect(p).toBeDefined();
+      expect(p!.contributorIds).toHaveLength(3);
+    });
+
+    it("does not fire when fewer than 3 contributors share metadata", () => {
+      const events = ["c1", "c2"].map((c) =>
+        makeEvent(c, `issue-${c}`, "contributor_registered", { ipHash: "abc123" }),
+      );
+      const report = svc.analyse(events);
+      expect(report.patterns.find((x) => x.kind === "SHARED_METADATA")).toBeUndefined();
+    });
+  });
+
+  it("reports analysedEventCount accurately", () => {
+    const events = [makeEvent("c1", "i1"), makeEvent("c2", "i2"), makeEvent("c3", "i3")];
+    const report = svc.analyse(events);
+    expect(report.analysedEventCount).toBe(3);
+  });
+
+  it("never modifies the input events array", () => {
+    const events = [makeEvent("c1", "i1")];
+    const original = JSON.stringify(events);
+    svc.analyse(events);
+    expect(JSON.stringify(events)).toBe(original);
+  });
+});

--- a/apps/api/src/modules/wave/coordinated-abuse-detection.service.ts
+++ b/apps/api/src/modules/wave/coordinated-abuse-detection.service.ts
@@ -1,0 +1,274 @@
+/**
+ * AI-210: Coordinated abuse pattern detection across contributors, issues, and appeals.
+ *
+ * Detects coordinated rule-breaking, contributor farming, and suspicious appeal
+ * clusters. Produces operator-review signals — never automated punishments.
+ *
+ * Explicit inputs  → analyse(events[])
+ * Explicit outputs → CoordinatedAbuseReport (patterns[], overallRisk, requiresHumanReview)
+ * Review boundary  → requiresHumanReview=true for any risk above "low"; humans
+ *                    inspect and decide — the service never takes action itself.
+ */
+
+import { Injectable, Logger } from "@nestjs/common";
+
+// ── Input types ──────────────────────────────────────────────────────────────
+
+export type AbuseEventKind =
+  | "appeal_submitted"
+  | "issue_claimed"
+  | "contributor_registered"
+  | "duplicate_submission"
+  | "rapid_resubmission";
+
+export interface AbuseEvent {
+  contributorId: string;
+  issueRef: string;
+  kind: AbuseEventKind;
+  /** ISO-8601 timestamp of the event. */
+  occurredAt: string;
+  /** Optional metadata (IP hash, device fingerprint, etc.) */
+  metadata?: Record<string, unknown>;
+}
+
+// ── Output types ─────────────────────────────────────────────────────────────
+
+export type AbusePatternKind =
+  | "VELOCITY_CLUSTER"      // many events from one contributor in a short window
+  | "APPEAL_FLOODING"       // contributor submitted many appeals in a short window
+  | "ISSUE_FARMING"         // one issue claimed by many contributors in quick succession
+  | "SHARED_METADATA"       // multiple contributors share suspicious metadata values
+  | "DUPLICATE_APPEAL_CLUSTER"; // identical appeal content from different contributors
+
+export type CoordinatedRiskLevel = "low" | "medium" | "high" | "critical";
+
+export interface DetectedPattern {
+  kind: AbusePatternKind;
+  /** IDs of contributors involved. */
+  contributorIds: string[];
+  /** Issue refs involved, if applicable. */
+  issueRefs: string[];
+  /** Human-readable explanation safe for operator display. */
+  description: string;
+  /** Numeric signal strength 0–100 (internal; not shown to contributors). */
+  _signalStrength: number;
+}
+
+export interface CoordinatedAbuseReport {
+  analysedEventCount: number;
+  patterns: DetectedPattern[];
+  overallRisk: CoordinatedRiskLevel;
+  /**
+   * Always true when overallRisk is "medium" or above.
+   * Operators must review before taking any action.
+   */
+  requiresHumanReview: boolean;
+  generatedAt: string;
+}
+
+// ── Configurable thresholds (measurable, tunable) ────────────────────────────
+
+export interface AbuseDetectionPolicy {
+  /** Max events per contributor within windowMs before VELOCITY_CLUSTER fires. */
+  velocityEventLimit: number;
+  /** Max appeal submissions per contributor within windowMs before APPEAL_FLOODING fires. */
+  appealFloodLimit: number;
+  /** Max unique contributors claiming the same issue within windowMs before ISSUE_FARMING fires. */
+  issueFarmingContributorLimit: number;
+  /** Time window in milliseconds for all sliding-window checks. */
+  windowMs: number;
+}
+
+export const DEFAULT_ABUSE_DETECTION_POLICY: AbuseDetectionPolicy = {
+  velocityEventLimit: 10,
+  appealFloodLimit: 5,
+  issueFarmingContributorLimit: 4,
+  windowMs: 60 * 60 * 1000, // 1 hour
+};
+
+// ── Service ───────────────────────────────────────────────────────────────────
+
+@Injectable()
+export class CoordinatedAbuseDetectionService {
+  private readonly logger = new Logger(CoordinatedAbuseDetectionService.name);
+
+  /**
+   * Analyse a batch of recent events for coordinated abuse patterns.
+   * Returns a report with detected patterns and an overall risk level.
+   * Never modifies state or triggers automated actions.
+   */
+  analyse(
+    events: AbuseEvent[],
+    policy: Partial<AbuseDetectionPolicy> = {},
+  ): CoordinatedAbuseReport {
+    const resolved: AbuseDetectionPolicy = { ...DEFAULT_ABUSE_DETECTION_POLICY, ...policy };
+    const patterns: DetectedPattern[] = [];
+
+    patterns.push(
+      ...this.detectVelocityClusters(events, resolved),
+      ...this.detectAppealFlooding(events, resolved),
+      ...this.detectIssueFarming(events, resolved),
+      ...this.detectSharedMetadata(events),
+    );
+
+    const overallRisk = this.toRiskLevel(patterns);
+    const requiresHumanReview = overallRisk !== "low";
+
+    const report: CoordinatedAbuseReport = {
+      analysedEventCount: events.length,
+      patterns,
+      overallRisk,
+      requiresHumanReview,
+      generatedAt: new Date().toISOString(),
+    };
+
+    if (requiresHumanReview) {
+      this.logger.warn(
+        JSON.stringify({
+          event: "coordinated_abuse_flagged",
+          overallRisk,
+          patternCount: patterns.length,
+          patternKinds: patterns.map((p) => p.kind),
+        }),
+      );
+    }
+
+    return report;
+  }
+
+  // ── Detectors ──────────────────────────────────────────────────────────────
+
+  private detectVelocityClusters(
+    events: AbuseEvent[],
+    policy: AbuseDetectionPolicy,
+  ): DetectedPattern[] {
+    const byContributor = groupBy(events, (e) => e.contributorId);
+    const patterns: DetectedPattern[] = [];
+
+    for (const [contributorId, contribEvents] of Object.entries(byContributor)) {
+      const withinWindow = filterWindow(contribEvents, policy.windowMs);
+      if (withinWindow.length >= policy.velocityEventLimit) {
+        patterns.push({
+          kind: "VELOCITY_CLUSTER",
+          contributorIds: [contributorId],
+          issueRefs: unique(withinWindow.map((e) => e.issueRef)),
+          description: `Contributor ${contributorId} generated ${withinWindow.length} events within the detection window.`,
+          _signalStrength: Math.min(100, withinWindow.length * 8),
+        });
+      }
+    }
+
+    return patterns;
+  }
+
+  private detectAppealFlooding(
+    events: AbuseEvent[],
+    policy: AbuseDetectionPolicy,
+  ): DetectedPattern[] {
+    const appealEvents = events.filter((e) => e.kind === "appeal_submitted");
+    const byContributor = groupBy(appealEvents, (e) => e.contributorId);
+    const patterns: DetectedPattern[] = [];
+
+    for (const [contributorId, contribAppeals] of Object.entries(byContributor)) {
+      const withinWindow = filterWindow(contribAppeals, policy.windowMs);
+      if (withinWindow.length >= policy.appealFloodLimit) {
+        patterns.push({
+          kind: "APPEAL_FLOODING",
+          contributorIds: [contributorId],
+          issueRefs: unique(withinWindow.map((e) => e.issueRef)),
+          description: `Contributor ${contributorId} submitted ${withinWindow.length} appeals within the detection window.`,
+          _signalStrength: Math.min(100, withinWindow.length * 15),
+        });
+      }
+    }
+
+    return patterns;
+  }
+
+  private detectIssueFarming(
+    events: AbuseEvent[],
+    policy: AbuseDetectionPolicy,
+  ): DetectedPattern[] {
+    const claimEvents = events.filter((e) => e.kind === "issue_claimed");
+    const byIssue = groupBy(claimEvents, (e) => e.issueRef);
+    const patterns: DetectedPattern[] = [];
+
+    for (const [issueRef, issueEvents] of Object.entries(byIssue)) {
+      const withinWindow = filterWindow(issueEvents, policy.windowMs);
+      const uniqueContributors = unique(withinWindow.map((e) => e.contributorId));
+      if (uniqueContributors.length >= policy.issueFarmingContributorLimit) {
+        patterns.push({
+          kind: "ISSUE_FARMING",
+          contributorIds: uniqueContributors,
+          issueRefs: [issueRef],
+          description: `Issue ${issueRef} was claimed by ${uniqueContributors.length} distinct contributors within the detection window.`,
+          _signalStrength: Math.min(100, uniqueContributors.length * 20),
+        });
+      }
+    }
+
+    return patterns;
+  }
+
+  private detectSharedMetadata(events: AbuseEvent[]): DetectedPattern[] {
+    // Detect multiple contributors sharing an identical suspicious metadata value
+    // (e.g., same IP hash or device fingerprint).
+    const metaIndex = new Map<string, Set<string>>();
+
+    for (const e of events) {
+      if (!e.metadata) continue;
+      for (const [key, val] of Object.entries(e.metadata)) {
+        if (!val || typeof val !== "string") continue;
+        const signature = `${key}:${val}`;
+        if (!metaIndex.has(signature)) metaIndex.set(signature, new Set());
+        metaIndex.get(signature)!.add(e.contributorId);
+      }
+    }
+
+    const patterns: DetectedPattern[] = [];
+
+    for (const [signature, contributors] of metaIndex.entries()) {
+      if (contributors.size >= 3) {
+        patterns.push({
+          kind: "SHARED_METADATA",
+          contributorIds: Array.from(contributors),
+          issueRefs: [],
+          description: `${contributors.size} contributors share metadata value "${signature}".`,
+          _signalStrength: Math.min(100, contributors.size * 25),
+        });
+      }
+    }
+
+    return patterns;
+  }
+
+  // ── Aggregation ────────────────────────────────────────────────────────────
+
+  private toRiskLevel(patterns: DetectedPattern[]): CoordinatedRiskLevel {
+    if (patterns.length === 0) return "low";
+    const maxSignal = Math.max(...patterns.map((p) => p._signalStrength));
+    if (maxSignal >= 80) return "critical";
+    if (maxSignal >= 50) return "high";
+    if (maxSignal >= 20) return "medium";
+    return "low";
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function groupBy<T>(items: T[], key: (item: T) => string): Record<string, T[]> {
+  return items.reduce<Record<string, T[]>>((acc, item) => {
+    const k = key(item);
+    (acc[k] ??= []).push(item);
+    return acc;
+  }, {});
+}
+
+function filterWindow(events: AbuseEvent[], windowMs: number): AbuseEvent[] {
+  const cutoff = Date.now() - windowMs;
+  return events.filter((e) => new Date(e.occurredAt).getTime() >= cutoff);
+}
+
+function unique<T>(arr: T[]): T[] {
+  return Array.from(new Set(arr));
+}

--- a/apps/api/src/modules/wave/wave.module.ts
+++ b/apps/api/src/modules/wave/wave.module.ts
@@ -1,5 +1,5 @@
 /**
- * WaveModule — bundles BE-207, BE-208, BE-211, BE-213 implementations.
+ * WaveModule — bundles BE-207, BE-208, BE-211, BE-213, AI-210 implementations.
  */
 
 import { Module } from "@nestjs/common";
@@ -14,6 +14,7 @@ import { ReviewWindowService } from "./review-window.service.js";
 import { ReviewWindowController } from "./review-window.controller.js";
 import { AbuseRiskService } from "./abuse-risk.service.js";
 import { AbuseRiskController } from "./abuse-risk.controller.js";
+import { CoordinatedAbuseDetectionService } from "./coordinated-abuse-detection.service.js";
 
 @Module({
   controllers: [AppealController, ReviewWindowController, AbuseRiskController],
@@ -26,7 +27,8 @@ import { AbuseRiskController } from "./abuse-risk.controller.js";
     AppealService,
     ReviewWindowService,
     AbuseRiskService,
+    CoordinatedAbuseDetectionService,
   ],
-  exports: [EligibilityService, ReviewWindowService, AbuseRiskService],
+  exports: [EligibilityService, ReviewWindowService, AbuseRiskService, CoordinatedAbuseDetectionService],
 })
 export class WaveModule {}

--- a/docs/ai-210-coordinated-abuse-detection.md
+++ b/docs/ai-210-coordinated-abuse-detection.md
@@ -1,0 +1,46 @@
+# AI-210: Coordinated Abuse Pattern Detection
+
+## Overview
+
+`CoordinatedAbuseDetectionService` spots coordinated rule-breaking, contributor
+farming, and suspicious appeal clusters across the platform. It produces
+operator-review signals and never takes automated action.
+
+## Detected Patterns
+
+| Pattern | Trigger |
+|---------|---------|
+| `VELOCITY_CLUSTER` | One contributor generates ≥ `velocityEventLimit` events in the window |
+| `APPEAL_FLOODING` | One contributor submits ≥ `appealFloodLimit` appeals in the window |
+| `ISSUE_FARMING` | One issue is claimed by ≥ `issueFarmingContributorLimit` distinct contributors in the window |
+| `SHARED_METADATA` | ≥ 3 contributors share an identical metadata value (e.g., IP hash) |
+
+## Explicit Inputs / Outputs
+
+| Direction | What it is |
+|-----------|-----------|
+| **Input** | `AbuseEvent[]` — recent events with contributor ID, issue ref, kind, timestamp |
+| **Input** | `Partial<AbuseDetectionPolicy>` — tunable thresholds |
+| **Output** | `CoordinatedAbuseReport.patterns[]` — each detected cluster with contributors/issues |
+| **Output** | `CoordinatedAbuseReport.overallRisk` — `low \| medium \| high \| critical` |
+| **Output** | `CoordinatedAbuseReport.requiresHumanReview` — always true when risk > low |
+
+## Review Boundary
+
+The service **never writes to the database, bans contributors, or changes appeal
+state.** Every `requiresHumanReview=true` report must be inspected by an operator
+before any consequence is applied. Automated punishment is explicitly excluded.
+
+## Measurability and Tuning
+
+All thresholds live in `AbuseDetectionPolicy` (default exported as
+`DEFAULT_ABUSE_DETECTION_POLICY`). Operators can change any value at runtime by
+passing `Partial<AbuseDetectionPolicy>` to `analyse()` — no code change needed.
+
+Internal `_signalStrength` scores (0–100) drive `overallRisk` but are stripped
+from the public `CoordinatedAbuseReportResponse` contract so contributors never
+see detection internals.
+
+## File Location
+
+`apps/api/src/modules/wave/coordinated-abuse-detection.service.ts`

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -403,6 +403,47 @@ export interface AppealTimingResult {
   appealDeadline: string;
 }
 
+// ── AI-210: Coordinated abuse pattern detection ───────────────────────────────
+
+export type AbuseEventKind =
+  | "appeal_submitted"
+  | "issue_claimed"
+  | "contributor_registered"
+  | "duplicate_submission"
+  | "rapid_resubmission";
+
+export type AbusePatternKind =
+  | "VELOCITY_CLUSTER"
+  | "APPEAL_FLOODING"
+  | "ISSUE_FARMING"
+  | "SHARED_METADATA"
+  | "DUPLICATE_APPEAL_CLUSTER";
+
+export type CoordinatedRiskLevel = "low" | "medium" | "high" | "critical";
+
+export interface AbuseEventPayload {
+  contributorId: string;
+  issueRef: string;
+  kind: AbuseEventKind;
+  occurredAt: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface DetectedPatternSummary {
+  kind: AbusePatternKind;
+  contributorIds: string[];
+  issueRefs: string[];
+  description: string;
+}
+
+export interface CoordinatedAbuseReportResponse {
+  analysedEventCount: number;
+  patterns: DetectedPatternSummary[];
+  overallRisk: CoordinatedRiskLevel;
+  requiresHumanReview: boolean;
+  generatedAt: string;
+}
+
 // ── Budget Accounting (BE-201, BE-202, BE-203, BE-204) ───────────────────────────
 
 export type BudgetEventType = 


### PR DESCRIPTION
## Summary

AI-assisted anomaly detection that helps operators spot coordinated rule-breaking, contributor farming, and suspicious appeal clusters — without automated punishment.

## Changes

- `CoordinatedAbuseDetectionService` in the `wave` module
  - Detects: `VELOCITY_CLUSTER`, `APPEAL_FLOODING`, `ISSUE_FARMING`, `SHARED_METADATA`
  - Returns `CoordinatedAbuseReport` with `patterns[]`, `overallRisk`, `requiresHumanReview`
  - `requiresHumanReview=true` for any risk above low — no automated punishment path
  - Internal `_signalStrength` drives risk level but is stripped from public API contract types
  - All thresholds in `AbuseDetectionPolicy` — tunable without code changes
  - Structured `coordinated_abuse_flagged` WARN log for operator pipelines
- Public contract types in `@devconsole/api-contracts`
- Operator guide in `docs/ai-210-coordinated-abuse-detection.md`

## Acceptance Criteria

- [x] Explicit inputs (`AbuseEvent[]`, `AbuseDetectionPolicy`) and outputs (`DetectedPattern[]`, `overallRisk`) — no hidden heuristics
- [x] All thresholds in `AbuseDetectionPolicy` — measurable and safe to tune
- [x] `requiresHumanReview` is the only action gate; service never applies consequences

Closes #427