### PR TITLE
feat: AI-203/204/205/207 — appeal evidence packs, eval harness, calibration dataset, explanations

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,8 @@ import { ReviewContextModule } from "./modules/review-context/review-context.mod
 import { BackgroundJobModule } from "./modules/jobs/background-job.module.js";
 import { WaveModule } from "./modules/wave/wave.module.js";
 import { BudgetModule } from "./modules/budget/budget.module.js";
+import { EvidencePackModule } from "./modules/evidence-pack/evidence-pack.module.js";
+import { AppealExplanationModule } from "./modules/appeal-explanation/appeal-explanation.module.js";
 
 @Module({
   imports: [
@@ -40,6 +42,8 @@ import { BudgetModule } from "./modules/budget/budget.module.js";
     ReviewContextModule,
     BackgroundJobModule,
     WaveModule,
+    EvidencePackModule,
+    AppealExplanationModule,
   ]
 })
 export class AppModule {}

--- a/apps/api/src/modules/appeal-explanation/appeal-explanation.controller.ts
+++ b/apps/api/src/modules/appeal-explanation/appeal-explanation.controller.ts
@@ -1,0 +1,21 @@
+import { Body, Controller, Post, UseGuards } from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { AppealExplanationService } from "./appeal-explanation.service.js";
+import type { ReviewEvidencePack } from "@devconsole/api-contracts";
+
+export interface GenerateExplanationDto {
+  pack: ReviewEvidencePack;
+  outcome: "approved" | "rejected" | "escalated";
+  confidence: "high" | "medium" | "low";
+}
+
+@Controller("appeal-explanations")
+@UseGuards(OwnerKeyGuard)
+export class AppealExplanationController {
+  constructor(private readonly service: AppealExplanationService) {}
+
+  @Post()
+  generate(@Body() dto: GenerateExplanationDto) {
+    return this.service.explain(dto.pack, dto.outcome, dto.confidence);
+  }
+}

--- a/apps/api/src/modules/appeal-explanation/appeal-explanation.module.ts
+++ b/apps/api/src/modules/appeal-explanation/appeal-explanation.module.ts
@@ -1,0 +1,10 @@
+import { Module } from "@nestjs/common";
+import { AppealExplanationController } from "./appeal-explanation.controller.js";
+import { AppealExplanationService } from "./appeal-explanation.service.js";
+
+@Module({
+  controllers: [AppealExplanationController],
+  providers: [AppealExplanationService],
+  exports: [AppealExplanationService],
+})
+export class AppealExplanationModule {}

--- a/apps/api/src/modules/appeal-explanation/appeal-explanation.service.ts
+++ b/apps/api/src/modules/appeal-explanation/appeal-explanation.service.ts
@@ -1,0 +1,85 @@
+/**
+ * AI-207: Generate contributor-facing appeal explanations from structured evidence.
+ *
+ * Produces concise, human-readable explanations that tell contributors why an
+ * appeal succeeded, failed, or needs human follow-up — without exposing
+ * sensitive moderation logic or model internals.
+ *
+ * Rules are explicit and enumerable so behaviour is measurable and safe to tune.
+ * Humans can always override the result when the system lacks confidence.
+ */
+
+import { Injectable } from "@nestjs/common";
+import type { ReviewEvidencePack, AppealExplanation } from "@devconsole/api-contracts";
+
+@Injectable()
+export class AppealExplanationService {
+  /**
+   * Derive a contributor-facing explanation from an assembled evidence pack
+   * and the evaluator's outcome.
+   *
+   * @param pack       The deterministic evidence pack (AI-203 output)
+   * @param outcome    The evaluator outcome: "approved" | "rejected" | "escalated"
+   * @param confidence Confidence level reported by the evaluator
+   */
+  explain(
+    pack: ReviewEvidencePack,
+    outcome: "approved" | "rejected" | "escalated",
+    confidence: "high" | "medium" | "low",
+  ): AppealExplanation {
+    const { reviewSummary: rs, priorDecisions } = pack;
+    const hasHumanOverride = priorDecisions.some((d) => d.humanOverride);
+
+    let headline: string;
+    let detail: string;
+    let nextSteps: string[];
+    const requiresHumanReview = outcome === "escalated" || confidence === "low";
+
+    if (outcome === "approved") {
+      headline = "Your appeal has been approved.";
+      detail =
+        rs.approvalCount >= 2 && rs.latestMergeStatus === "merged"
+          ? `Your pull request received ${rs.approvalCount} approvals and was merged. The evidence supports your appeal.`
+          : `The evidence provided supports your appeal. Points will be credited shortly.`;
+      nextSteps = ["Points will be applied to your account within one business day."];
+    } else if (outcome === "rejected") {
+      headline = "Your appeal was not approved.";
+      detail =
+        rs.changesRequestedCount > 0 && rs.approvalCount === 0
+          ? `The review history shows ${rs.changesRequestedCount} change request(s) and no approvals. The pull request was closed without being merged.`
+          : `The evidence did not meet the criteria for approval.`;
+      nextSteps = [
+        "Review the original feedback on your pull request.",
+        "If you believe this is incorrect, you may contact a maintainer for a manual review.",
+      ];
+    } else {
+      // escalated
+      headline = "Your appeal has been forwarded to a maintainer for review.";
+      if (hasHumanOverride) {
+        detail =
+          "A previous decision on this appeal was manually overridden. A maintainer will review the full history before making a final decision.";
+      } else if (rs.totalReviews === 0) {
+        detail =
+          "No review activity was found for the associated pull request. A maintainer will investigate.";
+      } else {
+        detail =
+          "The automated system could not reach a confident decision. A maintainer will review your appeal and respond directly.";
+      }
+      nextSteps = [
+        "A maintainer will review your case and respond within 5 business days.",
+        "No further action is required from you at this time.",
+      ];
+    }
+
+    return {
+      appealId: pack.appealId,
+      outcome,
+      confidence,
+      requiresHumanReview,
+      headline,
+      detail,
+      nextSteps,
+      generatedAt: new Date().toISOString(),
+    };
+  }
+}

--- a/apps/api/src/modules/evidence-pack/evidence-pack.controller.ts
+++ b/apps/api/src/modules/evidence-pack/evidence-pack.controller.ts
@@ -1,0 +1,15 @@
+import { Body, Controller, Post, UseGuards } from "@nestjs/common";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { EvidencePackService } from "./evidence-pack.service.js";
+import type { EvidencePackInput } from "@devconsole/api-contracts";
+
+@Controller("evidence-packs")
+@UseGuards(OwnerKeyGuard)
+export class EvidencePackController {
+  constructor(private readonly service: EvidencePackService) {}
+
+  @Post()
+  assemble(@Body() input: EvidencePackInput) {
+    return this.service.assemble(input);
+  }
+}

--- a/apps/api/src/modules/evidence-pack/evidence-pack.module.ts
+++ b/apps/api/src/modules/evidence-pack/evidence-pack.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { EvidencePackController } from "./evidence-pack.controller.js";
+import { EvidencePackService } from "./evidence-pack.service.js";
+
+@Module({
+  controllers: [EvidencePackController],
+  providers: [EvidencePackService, PrismaService],
+  exports: [EvidencePackService],
+})
+export class EvidencePackModule {}

--- a/apps/api/src/modules/evidence-pack/evidence-pack.service.ts
+++ b/apps/api/src/modules/evidence-pack/evidence-pack.service.ts
@@ -1,0 +1,69 @@
+/**
+ * AI-203: Assemble review evidence packs for AI-assisted appeal decisions.
+ *
+ * Packages code diffs, issue text, review comments, timestamps, and workflow
+ * context into a deterministic evidence object before any model evaluation runs.
+ */
+
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import type { ReviewEvidencePack, EvidencePackInput } from "@devconsole/api-contracts";
+
+@Injectable()
+export class EvidencePackService {
+  constructor(private readonly prisma: PrismaService) {}
+
+  /** Assemble a deterministic evidence pack for an appeal case. */
+  async assemble(input: EvidencePackInput): Promise<ReviewEvidencePack> {
+    const appeal = await this.prisma.appealCase.findFirst({
+      where: { id: input.appealId },
+    });
+    if (!appeal) throw new NotFoundException(`Appeal case not found: ${input.appealId}`);
+
+    const reviews = await this.prisma.reviewContext.findMany({
+      where: { pullRequestId: input.pullRequestId },
+      orderBy: { reviewedAt: "asc" },
+    });
+
+    const decisions = await this.prisma.appealDecision.findMany({
+      where: { appealId: input.appealId },
+      orderBy: { decidedAt: "desc" },
+    });
+
+    return {
+      appealId: appeal.id,
+      issueRef: appeal.issueRef,
+      pullRequestId: input.pullRequestId,
+      assembledAt: new Date().toISOString(),
+      appeal: {
+        reason: appeal.reason,
+        status: appeal.status,
+        createdAt: appeal.createdAt.toISOString(),
+        resolvedAt: appeal.resolvedAt?.toISOString() ?? null,
+        resolution: appeal.resolution ?? null,
+        evidenceJson: (appeal.evidenceJson as Record<string, unknown> | null) ?? null,
+      },
+      reviewSummary: {
+        totalReviews: reviews.length,
+        approvalCount: reviews.filter((r: { decision: string }) => r.decision === "approved").length,
+        changesRequestedCount: reviews.filter((r: { decision: string }) => r.decision === "changes_requested").length,
+        totalComments: reviews.reduce((sum: number, r: { commentCount: number }) => sum + r.commentCount, 0),
+        latestMergeStatus: reviews.at(-1)?.mergeStatus ?? "unknown",
+        reviewTimeline: reviews.map((r: { reviewerId: string; decision: string; commentCount: number; reviewedAt: Date }) => ({
+          reviewerId: r.reviewerId,
+          decision: r.decision,
+          commentCount: r.commentCount,
+          reviewedAt: r.reviewedAt.toISOString(),
+        })),
+      },
+      priorDecisions: decisions.map((d: { outcome: string; modelVersion: string | null; humanOverride: boolean; rationaleSummary: string | null; decidedAt: Date }) => ({
+        outcome: d.outcome,
+        modelVersion: d.modelVersion ?? null,
+        humanOverride: d.humanOverride,
+        rationaleSummary: d.rationaleSummary ?? null,
+        decidedAt: d.decidedAt.toISOString(),
+      })),
+      workflowContext: input.workflowContext ?? null,
+    };
+  }
+}

--- a/docs/appeal-calibration-dataset.md
+++ b/docs/appeal-calibration-dataset.md
@@ -1,0 +1,74 @@
+# Appeal Calibration Dataset
+
+**AI-205** — Labeled dataset for appeal quality and fairness calibration.
+
+## Purpose
+
+This dataset captures accepted, rejected, overridden, and ambiguous appeal cases so the AI evaluation system can be calibrated against real decision patterns. Every entry pairs a structured evidence pack with a human-assigned ground-truth label.
+
+## Labels
+
+| Label | Meaning |
+|---|---|
+| `approved` | Clear valid appeal — evidence strongly supports approval |
+| `rejected` | Clear invalid appeal — evidence supports rejection |
+| `escalated` | Ambiguous — insufficient evidence, escalate to human reviewer |
+| `overridden` | Model was wrong; a human reversed the decision |
+| `ambiguous` | Genuine grey area — useful for boundary calibration |
+
+## Sources
+
+| Source | Meaning |
+|---|---|
+| `synthetic` | Hand-crafted fixture case |
+| `production` | Sanitised from a real event (no PII) |
+| `replay` | Reconstructed from a replay pack scenario |
+
+## Files
+
+| File | Description |
+|---|---|
+| `docs/appeal-calibration-dataset.ndjson` | Newline-delimited JSON — one entry per line |
+| `scripts/appeal-calibration-dataset.ts` | Generator script — add entries here |
+
+## Generating / updating
+
+```bash
+# (Re)generate the NDJSON file from the script entries
+tsx scripts/appeal-calibration-dataset.ts
+
+# Write as a pretty-printed JSON array instead
+tsx scripts/appeal-calibration-dataset.ts --format json --out /tmp/dataset.json
+```
+
+## Using with the evaluator harness
+
+The harness (`scripts/appeal-eval-harness.ts`) accepts an external cases file. The calibration dataset uses the same `evidencePack` shape, so you can run the harness directly against it:
+
+```bash
+# Convert NDJSON → JSON array first, then run the harness
+node -e "
+  const fs = require('fs');
+  const lines = fs.readFileSync('docs/appeal-calibration-dataset.ndjson','utf8').trim().split('\n');
+  const cases = lines.map(l => {
+    const e = JSON.parse(l);
+    return { id: e.id, description: e.rationale, expectedOutcome: e.label, evidencePack: e.evidencePack };
+  });
+  fs.writeFileSync('/tmp/cal-cases.json', JSON.stringify(cases, null, 2));
+"
+tsx scripts/appeal-eval-harness.ts --cases /tmp/cal-cases.json --model rules-v1
+```
+
+## Adding entries
+
+1. Open `scripts/appeal-calibration-dataset.ts`.
+2. Append a new `CalibrationEntry` to the `ENTRIES` array.
+3. Set `source: "production"` only if the data has been sanitised (no real contributor IDs, issue refs, or emails).
+4. Re-run the generator: `tsx scripts/appeal-calibration-dataset.ts`.
+5. Commit both the updated script and the regenerated `.ndjson` file.
+
+## Fairness guidelines
+
+- Aim for balanced label distribution. If `approved` entries dominate, add `rejected` and `ambiguous` cases to prevent the evaluator from developing an approval bias.
+- Include at least two `overridden` entries per wave cycle so the model's failure modes are visible.
+- Review `ambiguous` entries periodically — if a human panel reaches consensus on the correct outcome, promote the entry to `approved` or `rejected` and document the reasoning.

--- a/packages/api-contracts/src/index.ts
+++ b/packages/api-contracts/src/index.ts
@@ -502,3 +502,58 @@ export interface ReconcileBudgetPayload {
   organizationId: string;
   dryRun?: boolean;
 }
+
+// ── AI Appeal Pipeline (AI-203, AI-207) ───────────────────────────────────────
+
+export interface EvidencePackInput {
+  appealId: string;
+  pullRequestId: string;
+  workflowContext?: Record<string, unknown>;
+}
+
+export interface ReviewEvidencePack {
+  appealId: string;
+  issueRef: string;
+  pullRequestId: string;
+  assembledAt: string;
+  appeal: {
+    reason: string;
+    status: string;
+    createdAt: string;
+    resolvedAt: string | null;
+    resolution: string | null;
+    evidenceJson: Record<string, unknown> | null;
+  };
+  reviewSummary: {
+    totalReviews: number;
+    approvalCount: number;
+    changesRequestedCount: number;
+    totalComments: number;
+    latestMergeStatus: string;
+    reviewTimeline: Array<{
+      reviewerId: string;
+      decision: string;
+      commentCount: number;
+      reviewedAt: string;
+    }>;
+  };
+  priorDecisions: Array<{
+    outcome: string;
+    modelVersion: string | null;
+    humanOverride: boolean;
+    rationaleSummary: string | null;
+    decidedAt: string;
+  }>;
+  workflowContext: Record<string, unknown> | null;
+}
+
+export interface AppealExplanation {
+  appealId: string;
+  outcome: "approved" | "rejected" | "escalated";
+  confidence: "high" | "medium" | "low";
+  requiresHumanReview: boolean;
+  headline: string;
+  detail: string;
+  nextSteps: string[];
+  generatedAt: string;
+}

--- a/scripts/appeal-calibration-dataset.ts
+++ b/scripts/appeal-calibration-dataset.ts
@@ -1,0 +1,266 @@
+#!/usr/bin/env tsx
+/**
+ * AI-205: Labeled calibration dataset for appeal quality and fairness.
+ *
+ * Builds and maintains a dataset capturing accepted, rejected, overridden, and
+ * ambiguous appeal cases so the AI system can be calibrated against real decision
+ * patterns. The dataset is written as newline-delimited JSON (NDJSON) so it can
+ * be consumed by offline tools, notebooks, or the eval harness.
+ *
+ * Usage:
+ *   tsx scripts/appeal-calibration-dataset.ts [--out <path>] [--format json|ndjson]
+ *
+ * Options:
+ *   --out     Output file path  (default: docs/appeal-calibration-dataset.ndjson)
+ *   --format  json | ndjson     (default: ndjson)
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+
+const args = process.argv.slice(2);
+let outPath = path.join(ROOT, "docs/appeal-calibration-dataset.ndjson");
+let format: "json" | "ndjson" = "ndjson";
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--out" && args[i + 1]) outPath = path.resolve(args[++i]);
+  if (args[i] === "--format" && (args[i + 1] === "json" || args[i + 1] === "ndjson")) {
+    format = args[++i] as "json" | "ndjson";
+  }
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type CalibrationLabel =
+  | "approved"        // clear valid appeal — should be approved
+  | "rejected"        // clear invalid appeal — should be rejected
+  | "escalated"       // ambiguous — requires human review
+  | "overridden"      // model was wrong; human reversed the decision
+  | "ambiguous";      // genuine grey area, useful for boundary calibration
+
+export interface CalibrationEntry {
+  id: string;
+  label: CalibrationLabel;
+  /** Free-text note explaining why this label was assigned */
+  rationale: string;
+  /** Source of this entry: "synthetic" | "production" | "replay" */
+  source: "synthetic" | "production" | "replay";
+  addedAt: string;
+  evidencePack: {
+    issueRef: string;
+    appealReason: string;
+    reviewSummary: {
+      totalReviews: number;
+      approvalCount: number;
+      changesRequestedCount: number;
+      totalComments: number;
+      latestMergeStatus: "open" | "merged" | "closed" | "unknown";
+    };
+    priorDecisions: Array<{ outcome: string; humanOverride: boolean }>;
+    workflowContext: Record<string, unknown> | null;
+  };
+}
+
+// ── Seed dataset ──────────────────────────────────────────────────────────────
+
+const ENTRIES: CalibrationEntry[] = [
+  {
+    id: "cal-001",
+    label: "approved",
+    rationale: "PR merged with 2 approvals, 0 change requests, well-documented reason.",
+    source: "synthetic",
+    addedAt: "2026-01-10T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#201",
+      appealReason:
+        "My PR was approved by two maintainers and merged but the wave points were never credited.",
+      reviewSummary: {
+        totalReviews: 3,
+        approvalCount: 2,
+        changesRequestedCount: 0,
+        totalComments: 5,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [],
+      workflowContext: { waveId: "wave-5", expectedPoints: 100 },
+    },
+  },
+  {
+    id: "cal-002",
+    label: "rejected",
+    rationale: "PR closed with no approvals and multiple change requests; appeal reason is generic.",
+    source: "synthetic",
+    addedAt: "2026-01-10T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#202",
+      appealReason: "I feel the review was unfair.",
+      reviewSummary: {
+        totalReviews: 2,
+        approvalCount: 0,
+        changesRequestedCount: 3,
+        totalComments: 9,
+        latestMergeStatus: "closed",
+      },
+      priorDecisions: [],
+      workflowContext: null,
+    },
+  },
+  {
+    id: "cal-003",
+    label: "overridden",
+    rationale:
+      "Model initially rejected but maintainer overrode to approved after reviewing diff manually.",
+    source: "replay",
+    addedAt: "2026-02-15T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#203",
+      appealReason:
+        "The automated system missed that the second reviewer approved after requesting changes.",
+      reviewSummary: {
+        totalReviews: 4,
+        approvalCount: 1,
+        changesRequestedCount: 2,
+        totalComments: 12,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [{ outcome: "rejected", humanOverride: true }],
+      workflowContext: { reviewTimingAnomalyFlag: true },
+    },
+  },
+  {
+    id: "cal-004",
+    label: "escalated",
+    rationale: "No review context found; appeal timing is within policy but evidence is thin.",
+    source: "synthetic",
+    addedAt: "2026-02-20T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#204",
+      appealReason: "The review window passed without my PR being reviewed.",
+      reviewSummary: {
+        totalReviews: 0,
+        approvalCount: 0,
+        changesRequestedCount: 0,
+        totalComments: 0,
+        latestMergeStatus: "open",
+      },
+      priorDecisions: [],
+      workflowContext: { timeSinceSubmissionHours: 72, reviewWindowHours: 48 },
+    },
+  },
+  {
+    id: "cal-005",
+    label: "ambiguous",
+    rationale:
+      "One approval and one change request; PR merged after conflict resolution. Boundary case for tuning.",
+    source: "production",
+    addedAt: "2026-03-05T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#205",
+      appealReason:
+        "The change request was addressed and resolved before merge but points were withheld.",
+      reviewSummary: {
+        totalReviews: 2,
+        approvalCount: 1,
+        changesRequestedCount: 1,
+        totalComments: 6,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [],
+      workflowContext: { changeRequestResolvedBeforeMerge: true },
+    },
+  },
+  {
+    id: "cal-006",
+    label: "approved",
+    rationale: "Budget reservation was cancelled due to cap exhaustion; contributor was verified before cancellation.",
+    source: "replay",
+    addedAt: "2026-03-10T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#206",
+      appealReason:
+        "My reservation was cancelled due to budget pressure even though I was already verified.",
+      reviewSummary: {
+        totalReviews: 1,
+        approvalCount: 1,
+        changesRequestedCount: 0,
+        totalComments: 2,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [],
+      workflowContext: {
+        budgetCapExhaustedAtCancellation: true,
+        contributorVerifiedBeforeReservation: true,
+      },
+    },
+  },
+  {
+    id: "cal-007",
+    label: "rejected",
+    rationale: "Duplicate submission pattern detected; two accounts submitted the same issue ref.",
+    source: "synthetic",
+    addedAt: "2026-04-01T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#207",
+      appealReason: "I submitted this issue first.",
+      reviewSummary: {
+        totalReviews: 1,
+        approvalCount: 0,
+        changesRequestedCount: 1,
+        totalComments: 1,
+        latestMergeStatus: "closed",
+      },
+      priorDecisions: [],
+      workflowContext: { duplicateSubmissionDetected: true, duplicateAccountCount: 2 },
+    },
+  },
+  {
+    id: "cal-008",
+    label: "escalated",
+    rationale: "Human override history exists but reason for original override is undocumented.",
+    source: "production",
+    addedAt: "2026-04-15T00:00:00.000Z",
+    evidencePack: {
+      issueRef: "org/repo#208",
+      appealReason: "A previous decision was reversed but I still haven't received points.",
+      reviewSummary: {
+        totalReviews: 3,
+        approvalCount: 2,
+        changesRequestedCount: 0,
+        totalComments: 3,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [
+        { outcome: "rejected", humanOverride: false },
+        { outcome: "approved", humanOverride: true },
+      ],
+      workflowContext: null,
+    },
+  },
+];
+
+// ── Write output ──────────────────────────────────────────────────────────────
+
+const dir = path.dirname(outPath);
+if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+
+if (format === "ndjson") {
+  fs.writeFileSync(outPath, ENTRIES.map((e) => JSON.stringify(e)).join("\n") + "\n");
+} else {
+  fs.writeFileSync(outPath, JSON.stringify(ENTRIES, null, 2) + "\n");
+}
+
+console.log(`\n📊  Appeal Calibration Dataset\n`);
+console.log(`  Entries  : ${ENTRIES.length}`);
+
+const byLabel: Record<string, number> = {};
+for (const e of ENTRIES) byLabel[e.label] = (byLabel[e.label] ?? 0) + 1;
+for (const [label, count] of Object.entries(byLabel)) {
+  console.log(`  ${label.padEnd(12)}: ${count}`);
+}
+
+console.log(`\n  Format   : ${format}`);
+console.log(`  Written  : ${outPath}\n`);

--- a/scripts/appeal-eval-harness.ts
+++ b/scripts/appeal-eval-harness.ts
@@ -1,0 +1,296 @@
+#!/usr/bin/env tsx
+/**
+ * AI-204: Evaluator harness for appeal-model experiments.
+ *
+ * Replays historical or synthetic appeal cases against different prompt
+ * configurations and model versions without touching live contributor state.
+ * All evaluation is read-only and deterministic.
+ *
+ * Usage:
+ *   tsx scripts/appeal-eval-harness.ts [--cases <path>] [--model <version>] [--out <path>]
+ *
+ * Options:
+ *   --cases  Path to a JSON file containing AppealEvalCase[]  (default: built-in fixtures)
+ *   --model  Model version label for result attribution        (default: "rules-v1")
+ *   --out    Write JSON results to this path instead of stdout
+ */
+
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── CLI args ──────────────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+let casesPath: string | undefined;
+let modelVersion = "rules-v1";
+let outPath: string | undefined;
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--cases" && args[i + 1]) casesPath = path.resolve(args[++i]);
+  if (args[i] === "--model" && args[i + 1]) modelVersion = args[++i];
+  if (args[i] === "--out" && args[i + 1]) outPath = path.resolve(args[++i]);
+}
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export type EvalOutcome = "approved" | "rejected" | "escalated";
+export type EvalLabel = "correct" | "incorrect" | "uncertain";
+
+export interface AppealEvalCase {
+  id: string;
+  description: string;
+  /** Ground-truth label set by a human reviewer */
+  expectedOutcome: EvalOutcome;
+  evidencePack: {
+    issueRef: string;
+    appealReason: string;
+    reviewSummary: {
+      totalReviews: number;
+      approvalCount: number;
+      changesRequestedCount: number;
+      totalComments: number;
+      latestMergeStatus: string;
+    };
+    priorDecisions: Array<{ outcome: EvalOutcome; humanOverride: boolean }>;
+    workflowContext: Record<string, unknown> | null;
+  };
+}
+
+export interface EvalResult {
+  caseId: string;
+  modelVersion: string;
+  predictedOutcome: EvalOutcome;
+  confidence: "high" | "medium" | "low";
+  label: EvalLabel;
+  reasoning: string;
+  evaluatedAt: string;
+}
+
+export interface EvalReport {
+  modelVersion: string;
+  totalCases: number;
+  correct: number;
+  incorrect: number;
+  uncertain: number;
+  accuracy: number;
+  escalationRate: number;
+  results: EvalResult[];
+  generatedAt: string;
+}
+
+// ── Deterministic rule-based evaluator ───────────────────────────────────────
+// This is intentionally explicit so behavior is measurable and safe to tune.
+
+function evaluate(c: AppealEvalCase, model: string): EvalResult {
+  const { reviewSummary: rs, priorDecisions, appealReason } = c.evidencePack;
+  const now = new Date().toISOString();
+
+  // Escalate if there is conflicting human override history
+  const hasHumanOverride = priorDecisions.some((d) => d.humanOverride);
+  if (hasHumanOverride) {
+    return {
+      caseId: c.id,
+      modelVersion: model,
+      predictedOutcome: "escalated",
+      confidence: "high",
+      label: c.expectedOutcome === "escalated" ? "correct" : "incorrect",
+      reasoning: "Prior human override detected — escalate for human review.",
+      evaluatedAt: now,
+    };
+  }
+
+  // Strong approval signal: multiple approvals, no changes requested, PR merged
+  if (
+    rs.approvalCount >= 2 &&
+    rs.changesRequestedCount === 0 &&
+    rs.latestMergeStatus === "merged"
+  ) {
+    const outcome: EvalOutcome = "approved";
+    return {
+      caseId: c.id,
+      modelVersion: model,
+      predictedOutcome: outcome,
+      confidence: "high",
+      label: c.expectedOutcome === outcome ? "correct" : "incorrect",
+      reasoning: "≥2 approvals, 0 change requests, PR merged → approve.",
+      evaluatedAt: now,
+    };
+  }
+
+  // Clear rejection: no approvals, multiple change requests, PR closed
+  if (
+    rs.approvalCount === 0 &&
+    rs.changesRequestedCount >= 2 &&
+    rs.latestMergeStatus === "closed"
+  ) {
+    const outcome: EvalOutcome = "rejected";
+    return {
+      caseId: c.id,
+      modelVersion: model,
+      predictedOutcome: outcome,
+      confidence: "high",
+      label: c.expectedOutcome === outcome ? "correct" : "incorrect",
+      reasoning: "0 approvals, ≥2 change requests, PR closed → reject.",
+      evaluatedAt: now,
+    };
+  }
+
+  // Vague reason with borderline signals → low confidence, escalate
+  const vagueReasonKeywords = ["unfair", "mistake", "error", "wrong"];
+  const reasonLower = appealReason.toLowerCase();
+  const isVague = vagueReasonKeywords.some((kw) => reasonLower.includes(kw)) && appealReason.length < 80;
+
+  if (isVague || rs.totalReviews === 0) {
+    return {
+      caseId: c.id,
+      modelVersion: model,
+      predictedOutcome: "escalated",
+      confidence: "low",
+      label: c.expectedOutcome === "escalated" ? "correct" : "uncertain",
+      reasoning: "Insufficient evidence or vague appeal reason — escalate for human review.",
+      evaluatedAt: now,
+    };
+  }
+
+  // Default: approve when at least one approval and no strong rejection signal
+  const outcome: EvalOutcome = rs.approvalCount >= 1 ? "approved" : "escalated";
+  return {
+    caseId: c.id,
+    modelVersion: model,
+    predictedOutcome: outcome,
+    confidence: "medium",
+    label: c.expectedOutcome === outcome ? "correct" : "uncertain",
+    reasoning: `Borderline case: ${rs.approvalCount} approval(s), ${rs.changesRequestedCount} change request(s).`,
+    evaluatedAt: now,
+  };
+}
+
+// ── Built-in fixture cases ────────────────────────────────────────────────────
+
+const FIXTURE_CASES: AppealEvalCase[] = [
+  {
+    id: "case-approved-clear",
+    description: "Clearly valid appeal: merged PR with multiple approvals",
+    expectedOutcome: "approved",
+    evidencePack: {
+      issueRef: "org/repo#101",
+      appealReason: "My PR was approved and merged but the wave points were not credited.",
+      reviewSummary: {
+        totalReviews: 3,
+        approvalCount: 2,
+        changesRequestedCount: 0,
+        totalComments: 4,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [],
+      workflowContext: null,
+    },
+  },
+  {
+    id: "case-rejected-clear",
+    description: "Clearly invalid appeal: closed PR with no approvals",
+    expectedOutcome: "rejected",
+    evidencePack: {
+      issueRef: "org/repo#102",
+      appealReason: "I submitted the PR but it was never reviewed fairly.",
+      reviewSummary: {
+        totalReviews: 2,
+        approvalCount: 0,
+        changesRequestedCount: 3,
+        totalComments: 7,
+        latestMergeStatus: "closed",
+      },
+      priorDecisions: [],
+      workflowContext: null,
+    },
+  },
+  {
+    id: "case-escalated-human-override",
+    description: "Prior human override — must be escalated regardless of signals",
+    expectedOutcome: "escalated",
+    evidencePack: {
+      issueRef: "org/repo#103",
+      appealReason: "I believe the original decision was incorrect.",
+      reviewSummary: {
+        totalReviews: 2,
+        approvalCount: 1,
+        changesRequestedCount: 1,
+        totalComments: 2,
+        latestMergeStatus: "merged",
+      },
+      priorDecisions: [{ outcome: "rejected", humanOverride: true }],
+      workflowContext: null,
+    },
+  },
+  {
+    id: "case-escalated-vague",
+    description: "Vague short reason with no strong review signal",
+    expectedOutcome: "escalated",
+    evidencePack: {
+      issueRef: "org/repo#104",
+      appealReason: "This is wrong",
+      reviewSummary: {
+        totalReviews: 0,
+        approvalCount: 0,
+        changesRequestedCount: 0,
+        totalComments: 0,
+        latestMergeStatus: "open",
+      },
+      priorDecisions: [],
+      workflowContext: null,
+    },
+  },
+];
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+const cases: AppealEvalCase[] = casesPath
+  ? (JSON.parse(fs.readFileSync(casesPath, "utf8")) as AppealEvalCase[])
+  : FIXTURE_CASES;
+
+console.log(`\n🧪  Appeal Evaluator Harness  [model=${modelVersion}]\n`);
+console.log(`Running ${cases.length} case(s)...\n`);
+
+const results: EvalResult[] = cases.map((c) => evaluate(c, modelVersion));
+
+const correct = results.filter((r) => r.label === "correct").length;
+const incorrect = results.filter((r) => r.label === "incorrect").length;
+const uncertain = results.filter((r) => r.label === "uncertain").length;
+const escalated = results.filter((r) => r.predictedOutcome === "escalated").length;
+
+const report: EvalReport = {
+  modelVersion,
+  totalCases: cases.length,
+  correct,
+  incorrect,
+  uncertain,
+  accuracy: cases.length > 0 ? correct / cases.length : 0,
+  escalationRate: cases.length > 0 ? escalated / cases.length : 0,
+  results,
+  generatedAt: new Date().toISOString(),
+};
+
+// Print per-case summary
+for (const r of results) {
+  const icon = r.label === "correct" ? "✅" : r.label === "incorrect" ? "❌" : "⚠️ ";
+  console.log(`  ${icon}  [${r.caseId}]  predicted=${r.predictedOutcome}  confidence=${r.confidence}`);
+  console.log(`       ${r.reasoning}`);
+}
+
+console.log(`\n── Summary ──────────────────────────────────────────`);
+console.log(`  Total cases  : ${report.totalCases}`);
+console.log(`  Correct      : ${correct}`);
+console.log(`  Incorrect    : ${incorrect}`);
+console.log(`  Uncertain    : ${uncertain}`);
+console.log(`  Accuracy     : ${(report.accuracy * 100).toFixed(1)}%`);
+console.log(`  Escalation % : ${(report.escalationRate * 100).toFixed(1)}%`);
+
+if (outPath) {
+  fs.writeFileSync(outPath, JSON.stringify(report, null, 2));
+  console.log(`\n  Report written to: ${outPath}`);
+}
+
+console.log();


### PR DESCRIPTION
## Summary

Implements all four AI/Automation track issues assigned to me.

### AI-203 — Assemble review evidence packs (closes #420)
- `EvidencePackService.assemble()` packages appeal details, review timeline, prior decisions, and workflow context into a deterministic `ReviewEvidencePack` before any model evaluation runs
- `POST /evidence-packs` endpoint (owner-key guarded)

### AI-204 — Evaluator harness (closes #421)
- `scripts/appeal-eval-harness.ts` — read-only replay script with explicit rule-based logic (no live DB access)
- Emits per-case labels and an `EvalReport` with accuracy + escalation rate
- Accepts `--cases`, `--model`, `--out` flags; ships four built-in fixture cases

### AI-205 — Calibration dataset (closes #422)
- `scripts/appeal-calibration-dataset.ts` — 8 seed entries spanning all five labels: `approved`, `rejected`, `escalated`, `overridden`, `ambiguous`
- `docs/appeal-calibration-dataset.md` — label definitions, fairness guidelines, instructions for adding entries

### AI-207 — Contributor-facing explanations (closes #424)
- `AppealExplanationService.explain(pack, outcome, confidence)` maps evidence pack + evaluator outcome to headline / detail / next-steps without leaking moderation internals
- Sets `requiresHumanReview: true` when confidence is low or outcome is escalated
- `POST /appeal-explanations` endpoint (owner-key guarded)

### Wiring
- Both modules registered in `AppModule`
- `EvidencePackInput`, `ReviewEvidencePack`, `AppealExplanation` exported from `@devconsole/api-contracts`

## Acceptance criteria
- ✅ Explicit inputs, outputs, and review boundaries — no hidden heuristics
- ✅ Measurable and tunable — eval harness + labeled calibration dataset
- ✅ Human override path — `requiresHumanReview` flag + escalation outcome

## Testing
No new type errors introduced in the new modules (verified with `tsc -p apps/api/tsconfig.json --noEmit`).