### PR TITLE
feat(ai-211-214): add automation pipeline modules

### DIFF
--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -351,3 +351,79 @@ model BudgetEvent {
   @@index([eventType])
   @@map("budget_events")
 }
+
+/// AI-211: Rule-based classification result for a support ticket.
+model TicketClassification {
+  id                String    @id @default(cuid())
+  ticketId          String    @unique @map("ticket_id")
+  suggestedCategory String    @map("suggested_category")
+  suggestedPriority String    @map("suggested_priority")
+  suggestedRoute    String    @map("suggested_route")
+  confidence        Float
+  signals           Json
+  modelVersion      String    @map("model_version")
+  humanOverride     Boolean   @default(false) @map("human_override")
+  overriddenBy      String?   @map("overridden_by")
+  overrideNote      String?   @map("override_note")
+  overriddenAt      DateTime? @map("overridden_at")
+  createdAt         DateTime  @default(now()) @map("created_at")
+
+  @@index([ticketId])
+  @@index([suggestedRoute])
+  @@map("ticket_classifications")
+}
+
+/// AI-212: Structured summary of a maintainer review thread for appeal triage.
+model ReviewSummary {
+  id            String   @id @default(cuid())
+  pullRequestId String   @unique @map("pull_request_id")
+  summaryText   String   @map("summary_text")
+  keySignals    Json     @map("key_signals")
+  modelVersion  String   @map("model_version")
+  humanOverride Boolean  @default(false) @map("human_override")
+  overriddenBy  String?  @map("overridden_by")
+  overrideNote  String?  @map("override_note")
+  createdAt     DateTime @default(now()) @map("created_at")
+  updatedAt     DateTime @updatedAt @map("updated_at")
+
+  @@index([pullRequestId])
+  @@map("review_summaries")
+}
+
+/// AI-213: Signal-based recommendation for an org budget exception review.
+model BudgetExceptionRecommendation {
+  id             String    @id @default(cuid())
+  organizationId String    @unique @map("organization_id")
+  signals        Json
+  recommendation String
+  confidence     Float
+  modelVersion   String    @map("model_version")
+  humanDecision  String?   @map("human_decision")
+  decidedBy      String?   @map("decided_by")
+  decisionNote   String?   @map("decision_note")
+  decidedAt      DateTime? @map("decided_at")
+  createdAt      DateTime  @default(now()) @map("created_at")
+
+  @@index([organizationId])
+  @@index([recommendation])
+  @@map("budget_exception_recommendations")
+}
+
+/// AI-214: Point-in-time snapshot of an AI pipeline health metric.
+model AiMetricSnapshot {
+  id             String   @id @default(cuid())
+  snapshotAt     DateTime @default(now()) @map("snapshot_at")
+  modelVersion   String   @map("model_version")
+  metricType     String   @map("metric_type")
+  value          Float
+  windowHours    Int      @map("window_hours")
+  metadata       Json?
+  alertTriggered Boolean  @default(false) @map("alert_triggered")
+  alertThreshold Float?   @map("alert_threshold")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  @@index([metricType, snapshotAt])
+  @@index([modelVersion])
+  @@map("ai_metric_snapshots")
+}
+

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -17,6 +17,10 @@ import { ReviewContextModule } from "./modules/review-context/review-context.mod
 import { BackgroundJobModule } from "./modules/jobs/background-job.module.js";
 import { WaveModule } from "./modules/wave/wave.module.js";
 import { BudgetModule } from "./modules/budget/budget.module.js";
+import { TicketClassifierModule } from "./modules/ticket-classifier/ticket-classifier.module.js";
+import { ReviewSummarizerModule } from "./modules/review-summarizer/review-summarizer.module.js";
+import { BudgetExceptionModule } from "./modules/budget-exception/budget-exception.module.js";
+import { AiMonitorModule } from "./modules/ai-monitor/ai-monitor.module.js";
 
 @Module({
   imports: [
@@ -40,6 +44,11 @@ import { BudgetModule } from "./modules/budget/budget.module.js";
     ReviewContextModule,
     BackgroundJobModule,
     WaveModule,
+    BudgetModule,
+    TicketClassifierModule,
+    ReviewSummarizerModule,
+    BudgetExceptionModule,
+    AiMonitorModule,
   ]
 })
 export class AppModule {}

--- a/apps/api/src/modules/ai-monitor/ai-monitor.controller.ts
+++ b/apps/api/src/modules/ai-monitor/ai-monitor.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import {
+  AiMonitorService,
+  ListSnapshotsDto,
+  RecordSnapshotDto,
+} from "./ai-monitor.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("ai-monitor")
+@UseGuards(OwnerKeyGuard)
+export class AiMonitorController {
+  constructor(private readonly service: AiMonitorService) {}
+
+  @Post("snapshot")
+  @HttpCode(HttpStatus.CREATED)
+  snapshot(@Body() dto: RecordSnapshotDto, @Req() req: Request) {
+    return this.service.snapshot(dto, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get()
+  list(@Query() query: ListSnapshotsDto) {
+    return this.service.list(query);
+  }
+
+  @Get("alerts")
+  listAlerts() {
+    return this.service.listAlerts();
+  }
+
+  @Get("summary")
+  summary() {
+    return this.service.summary();
+  }
+
+  @Get(":id")
+  get(@Param("id") id: string) {
+    return this.service.get(id);
+  }
+}

--- a/apps/api/src/modules/ai-monitor/ai-monitor.module.ts
+++ b/apps/api/src/modules/ai-monitor/ai-monitor.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { AiMonitorController } from "./ai-monitor.controller.js";
+import { AiMonitorService } from "./ai-monitor.service.js";
+
+@Module({
+  controllers: [AiMonitorController],
+  providers: [AiMonitorService, PrismaService, AuditService],
+  exports: [AiMonitorService],
+})
+export class AiMonitorModule {}

--- a/apps/api/src/modules/ai-monitor/ai-monitor.service.ts
+++ b/apps/api/src/modules/ai-monitor/ai-monitor.service.ts
@@ -1,0 +1,163 @@
+/**
+ * AI-214: Continuous monitoring for AI pipeline health.
+ *
+ * Snapshots precision, override rate, fairness drift, and queue health
+ * on demand. Each snapshot is immutable -- regressions are visible over time.
+ * Humans inspect the trend; the system never auto-tunes without approval.
+ */
+
+import { Injectable, NotFoundException, BadRequestException } from "@nestjs/common";
+import { IsString, IsNumber, IsOptional, IsInt, Min, Max, IsIn } from "class-validator";
+import { Type } from "class-transformer";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+
+export const MONITOR_MODEL_VERSION = "rules-v1.0.0" as const;
+
+export const METRIC_TYPES = [
+  "override_rate",
+  "classification_precision",
+  "fairness_drift",
+  "queue_health",
+] as const;
+export type MetricType = (typeof METRIC_TYPES)[number];
+
+export const ALERT_THRESHOLDS: Record<MetricType, number> = {
+  override_rate: 0.25,
+  classification_precision: 0.70,
+  fairness_drift: 0.15,
+  queue_health: 0.50,
+};
+
+export class RecordSnapshotDto {
+  @IsIn(METRIC_TYPES)
+  metricType!: MetricType;
+
+  @IsNumber()
+  value!: number;
+
+  @IsInt()
+  @Min(1)
+  @Max(720)
+  windowHours!: number;
+
+  @IsOptional()
+  metadata?: Record<string, unknown>;
+}
+
+export class ListSnapshotsDto {
+  @IsOptional()
+  @IsIn(METRIC_TYPES)
+  metricType?: MetricType;
+
+  @IsOptional()
+  @IsString()
+  modelVersion?: string;
+
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(1)
+  take?: number;
+}
+
+function deriveAlert(metricType: MetricType, value: number): boolean {
+  const threshold = ALERT_THRESHOLDS[metricType];
+  if (metricType === "classification_precision" || metricType === "queue_health") {
+    return value < threshold;
+  }
+  return value > threshold;
+}
+
+@Injectable()
+export class AiMonitorService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async snapshot(dto: RecordSnapshotDto, actorKey: string) {
+    const alertThreshold = ALERT_THRESHOLDS[dto.metricType];
+    const alertTriggered = deriveAlert(dto.metricType, dto.value);
+
+    const record = await this.prisma.aiMetricSnapshot.create({
+      data: {
+        modelVersion: MONITOR_MODEL_VERSION,
+        metricType: dto.metricType,
+        value: dto.value,
+        windowHours: dto.windowHours,
+        metadata: (dto.metadata ?? Prisma.JsonNull) as Prisma.InputJsonValue,
+        alertTriggered,
+        alertThreshold,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "ai_monitor.snapshot.recorded",
+      resourceType: "ai_metric_snapshot",
+      resourceId: record.id,
+      summary: `Metric ${dto.metricType}=${dto.value} (alert=${alertTriggered})`,
+      metadata: {
+        modelVersion: MONITOR_MODEL_VERSION,
+        windowHours: dto.windowHours,
+        alertThreshold,
+      } as Prisma.InputJsonValue,
+    });
+
+    return record;
+  }
+
+  @MapDbErrors()
+  async list(query: ListSnapshotsDto = {}) {
+    const take = query.take ?? 50;
+    return this.prisma.aiMetricSnapshot.findMany({
+      where: {
+        ...(query.metricType ? { metricType: query.metricType } : {}),
+        ...(query.modelVersion ? { modelVersion: query.modelVersion } : {}),
+      },
+      orderBy: { snapshotAt: "desc" },
+      take,
+    });
+  }
+
+  @MapDbErrors()
+  async listAlerts() {
+    return this.prisma.aiMetricSnapshot.findMany({
+      where: { alertTriggered: true },
+      orderBy: { snapshotAt: "desc" },
+      take: 100,
+    });
+  }
+
+  @MapDbErrors()
+  async get(id: string) {
+    const record = await this.prisma.aiMetricSnapshot.findUnique({ where: { id } });
+    if (!record) throw new NotFoundException("Metric snapshot not found");
+    return record;
+  }
+
+  /** Compute a summary of the latest value per metric type. */
+  @MapDbErrors()
+  async summary() {
+    const rows = await Promise.all(
+      METRIC_TYPES.map(async (metricType) => {
+        const latest = await this.prisma.aiMetricSnapshot.findFirst({
+          where: { metricType },
+          orderBy: { snapshotAt: "desc" },
+        });
+        return {
+          metricType,
+          latestValue: latest?.value ?? null,
+          alertThreshold: ALERT_THRESHOLDS[metricType],
+          alertTriggered: latest?.alertTriggered ?? false,
+          snapshotAt: latest?.snapshotAt ?? null,
+        };
+      }),
+    );
+    return rows;
+  }
+}

--- a/apps/api/src/modules/budget-exception/budget-exception.controller.ts
+++ b/apps/api/src/modules/budget-exception/budget-exception.controller.ts
@@ -1,0 +1,52 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import {
+  BudgetExceptionService,
+  DecideExceptionDto,
+  RecommendExceptionDto,
+} from "./budget-exception.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("budget-exception")
+@UseGuards(OwnerKeyGuard)
+export class BudgetExceptionController {
+  constructor(private readonly service: BudgetExceptionService) {}
+
+  @Post("recommend")
+  @HttpCode(HttpStatus.OK)
+  recommend(@Body() dto: RecommendExceptionDto, @Req() req: Request) {
+    return this.service.recommend(dto, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get("org/:organizationId")
+  getByOrg(@Param("organizationId") organizationId: string) {
+    return this.service.getByOrg(organizationId);
+  }
+
+  @Patch("org/:organizationId/decide")
+  decide(
+    @Param("organizationId") organizationId: string,
+    @Body() dto: DecideExceptionDto,
+    @Req() req: Request,
+  ) {
+    return this.service.decide(organizationId, (req as OwnerKeyRequest).ownerKey, dto);
+  }
+
+  @Get("pending")
+  listPending() {
+    return this.service.listPending();
+  }
+}

--- a/apps/api/src/modules/budget-exception/budget-exception.module.ts
+++ b/apps/api/src/modules/budget-exception/budget-exception.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { BudgetExceptionController } from "./budget-exception.controller.js";
+import { BudgetExceptionService } from "./budget-exception.service.js";
+
+@Module({
+  controllers: [BudgetExceptionController],
+  providers: [BudgetExceptionService, PrismaService, AuditService],
+  exports: [BudgetExceptionService],
+})
+export class BudgetExceptionModule {}

--- a/apps/api/src/modules/budget-exception/budget-exception.service.ts
+++ b/apps/api/src/modules/budget-exception/budget-exception.service.ts
@@ -1,0 +1,211 @@
+/**
+ * AI-213: Recommend org-budget exception reviews using structured signals.
+ *
+ * Derives utilization, pacing, and fairness signals from existing budget and
+ * reservation records. Final decisions always stay with humans.
+ */
+
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
+import { IsString, IsOptional } from "class-validator";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+
+export const EXCEPTION_MODEL_VERSION = "rules-v1.0.0" as const;
+
+export const RECOMMENDATIONS = ["review", "no-review", "escalate"] as const;
+export type Recommendation = (typeof RECOMMENDATIONS)[number];
+
+export interface ExceptionSignals {
+  totalBudget: number;
+  usedPoints: number;
+  pendingPoints: number;
+  utilizationRatio: number;
+  pendingReservationCount: number;
+  uniqueContributors: number;
+  highConcentration: boolean;
+}
+
+export class RecommendExceptionDto {
+  @IsString()
+  organizationId!: string;
+}
+
+export class DecideExceptionDto {
+  @IsString()
+  humanDecision!: string;
+  @IsOptional()
+  @IsString()
+  decisionNote?: string;
+}
+
+const UTILIZATION_REVIEW_THRESHOLD = 0.80;
+const UTILIZATION_ESCALATE_THRESHOLD = 0.95;
+const CONCENTRATION_RATIO = 0.5;
+
+async function buildSignals(
+  prisma: PrismaService,
+  organizationId: string,
+): Promise<ExceptionSignals> {
+  const budget = await prisma.organizationBudget.findFirst({
+    where: { organizationId },
+  });
+
+  const totalBudget = budget?.capPoints ?? 0;
+
+  const reservations = await prisma.pointReservation.findMany({
+    where: { organizationId },
+    select: { points: true, status: true, contributorId: true },
+  });
+
+  const usedPoints = reservations
+    .filter((r) => r.status === "released" || r.status === "settled")
+    .reduce((sum, r) => sum + r.points, 0);
+
+  const pending = reservations.filter((r) => r.status === "pending");
+  const pendingPoints = pending.reduce((sum, r) => sum + r.points, 0);
+  const pendingReservationCount = pending.length;
+
+  const allContributors = new Set(reservations.map((r) => r.contributorId));
+  const uniqueContributors = allContributors.size;
+
+  const topContributorPoints = uniqueContributors > 0
+    ? Math.max(
+        ...Array.from(allContributors).map((id) =>
+          reservations
+            .filter((r) => r.contributorId === id)
+            .reduce((sum, r) => sum + r.points, 0),
+        ),
+      )
+    : 0;
+
+  const utilizationRatio =
+    totalBudget > 0 ? (usedPoints + pendingPoints) / totalBudget : 0;
+
+  const highConcentration =
+    uniqueContributors > 0 &&
+    topContributorPoints / (usedPoints + pendingPoints || 1) >= CONCENTRATION_RATIO;
+
+  return {
+    totalBudget,
+    usedPoints,
+    pendingPoints,
+    utilizationRatio: Math.round(utilizationRatio * 1000) / 1000,
+    pendingReservationCount,
+    uniqueContributors,
+    highConcentration,
+  };
+}
+
+function deriveRecommendation(signals: ExceptionSignals): {
+  recommendation: Recommendation;
+  confidence: number;
+} {
+  if (signals.utilizationRatio >= UTILIZATION_ESCALATE_THRESHOLD) {
+    return { recommendation: "escalate", confidence: 0.9 };
+  }
+  if (
+    signals.utilizationRatio >= UTILIZATION_REVIEW_THRESHOLD ||
+    signals.highConcentration
+  ) {
+    return { recommendation: "review", confidence: 0.75 };
+  }
+  return { recommendation: "no-review", confidence: 0.8 };
+}
+
+@Injectable()
+export class BudgetExceptionService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async recommend(dto: RecommendExceptionDto, actorKey: string) {
+    const signals = await buildSignals(this.prisma, dto.organizationId);
+    const { recommendation, confidence } = deriveRecommendation(signals);
+
+    const record = await this.prisma.budgetExceptionRecommendation.upsert({
+      where: { organizationId: dto.organizationId },
+      create: {
+        organizationId: dto.organizationId,
+        signals: signals as unknown as Prisma.InputJsonValue,
+        recommendation,
+        confidence,
+        modelVersion: EXCEPTION_MODEL_VERSION,
+      },
+      update: {
+        signals: signals as unknown as Prisma.InputJsonValue,
+        recommendation,
+        confidence,
+        modelVersion: EXCEPTION_MODEL_VERSION,
+        humanDecision: null,
+        decidedBy: null,
+        decisionNote: null,
+        decidedAt: null,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "budget.exception.recommended",
+      resourceType: "budget_exception_recommendation",
+      resourceId: record.id,
+      summary: `Org ${dto.organizationId} exception recommendation: ${recommendation} (confidence=${confidence})`,
+      metadata: { modelVersion: EXCEPTION_MODEL_VERSION, signals } as unknown as Prisma.InputJsonValue,
+    });
+
+    return record;
+  }
+
+  @MapDbErrors()
+  async getByOrg(organizationId: string) {
+    const record = await this.prisma.budgetExceptionRecommendation.findUnique({
+      where: { organizationId },
+    });
+    if (!record) throw new NotFoundException("No recommendation found -- run recommend first");
+    return record;
+  }
+
+  @MapDbErrors()
+  async decide(organizationId: string, actorKey: string, dto: DecideExceptionDto) {
+    const existing = await this.prisma.budgetExceptionRecommendation.findUnique({
+      where: { organizationId },
+    });
+    if (!existing) throw new NotFoundException("No recommendation found -- run recommend first");
+
+    const updated = await this.prisma.budgetExceptionRecommendation.update({
+      where: { organizationId },
+      data: {
+        humanDecision: dto.humanDecision,
+        decidedBy: actorKey,
+        decisionNote: dto.decisionNote ?? null,
+        decidedAt: new Date(),
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "budget.exception.decided",
+      resourceType: "budget_exception_recommendation",
+      resourceId: existing.id,
+      summary: `Human decision on org ${organizationId}: ${dto.humanDecision}`,
+      metadata: { decisionNote: dto.decisionNote } as Prisma.InputJsonValue,
+    });
+
+    return updated;
+  }
+
+  @MapDbErrors()
+  async listPending() {
+    return this.prisma.budgetExceptionRecommendation.findMany({
+      where: { humanDecision: null },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/apps/api/src/modules/review-summarizer/review-summarizer.controller.ts
+++ b/apps/api/src/modules/review-summarizer/review-summarizer.controller.ts
@@ -1,0 +1,56 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import {
+  SummarizeReviewDto,
+  OverrideSummaryDto,
+  ReviewSummarizerService,
+} from "./review-summarizer.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("review-summarizer")
+@UseGuards(OwnerKeyGuard)
+export class ReviewSummarizerController {
+  constructor(private readonly service: ReviewSummarizerService) {}
+
+  @Post("summarize")
+  @HttpCode(HttpStatus.OK)
+  summarize(@Body() dto: SummarizeReviewDto, @Req() req: Request) {
+    return this.service.summarize(dto, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get("pr/:pullRequestId")
+  getByPr(@Param("pullRequestId") pullRequestId: string) {
+    return this.service.getByPr(pullRequestId);
+  }
+
+  @Patch("pr/:pullRequestId/override")
+  override(
+    @Param("pullRequestId") pullRequestId: string,
+    @Body() dto: OverrideSummaryDto,
+    @Req() req: Request,
+  ) {
+    return this.service.override(
+      pullRequestId,
+      (req as OwnerKeyRequest).ownerKey,
+      dto,
+    );
+  }
+
+  @Get("list")
+  list() {
+    return this.service.list();
+  }
+}

--- a/apps/api/src/modules/review-summarizer/review-summarizer.module.ts
+++ b/apps/api/src/modules/review-summarizer/review-summarizer.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { ReviewSummarizerController } from "./review-summarizer.controller.js";
+import { ReviewSummarizerService } from "./review-summarizer.service.js";
+
+@Module({
+  controllers: [ReviewSummarizerController],
+  providers: [ReviewSummarizerService, PrismaService, AuditService],
+  exports: [ReviewSummarizerService],
+})
+export class ReviewSummarizerModule {}

--- a/apps/api/src/modules/review-summarizer/review-summarizer.service.ts
+++ b/apps/api/src/modules/review-summarizer/review-summarizer.service.ts
@@ -1,0 +1,187 @@
+/**
+ * AI-212: Summarize maintainer review threads for faster appeal triage.
+ */
+
+import {
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { IsString, IsOptional } from "class-validator";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+
+export const SUMMARIZER_MODEL_VERSION = "rules-v1.0.0" as const;
+
+export interface SummarySignals {
+  reviewCount: number;
+  approvalCount: number;
+  approvalRatio: number;
+  totalComments: number;
+  totalRequestedChanges: number;
+  mergeStatus: string;
+  contested: boolean;
+  highCommentDensity: boolean;
+}
+
+export class SummarizeReviewDto {
+  @IsString()
+  pullRequestId!: string;
+}
+
+export class OverrideSummaryDto {
+  @IsString()
+  summaryText!: string;
+  @IsOptional()
+  @IsString()
+  overrideNote?: string;
+}
+
+const HIGH_COMMENT_THRESHOLD = 10;
+
+function buildSummary(
+  pullRequestId: string,
+  reviews: Array<{
+    decision: string;
+    commentCount: number;
+    requestedChangesCount: number;
+    mergeStatus: string;
+  }>,
+): { summaryText: string; signals: SummarySignals } {
+  const reviewCount = reviews.length;
+  const approvalCount = reviews.filter((r) => r.decision === "approved").length;
+  const approvalRatio = reviewCount > 0 ? approvalCount / reviewCount : 0;
+  const totalComments = reviews.reduce((sum, r) => sum + r.commentCount, 0);
+  const totalRequestedChanges = reviews.reduce(
+    (sum, r) => sum + r.requestedChangesCount,
+    0,
+  );
+  const mergeStatus = reviews[reviews.length - 1]?.mergeStatus ?? "unknown";
+  const contested = approvalCount > 0 && totalRequestedChanges > 0;
+  const highCommentDensity = totalComments >= HIGH_COMMENT_THRESHOLD;
+
+  const signals: SummarySignals = {
+    reviewCount,
+    approvalCount,
+    approvalRatio: Math.round(approvalRatio * 1000) / 1000,
+    totalComments,
+    totalRequestedChanges,
+    mergeStatus,
+    contested,
+    highCommentDensity,
+  };
+
+  const parts: string[] = [
+    `PR ${pullRequestId} has ${reviewCount} review${reviewCount !== 1 ? "s" : ""}: ` +
+      `${approvalCount} approval${approvalCount !== 1 ? "s" : ""}, ` +
+      `${totalRequestedChanges} change request${totalRequestedChanges !== 1 ? "s" : ""}.`,
+    `Total comments: ${totalComments}. Latest merge status: ${mergeStatus}.`,
+  ];
+
+  if (contested) parts.push("Thread is contested (approvals and change requests both present).");
+  if (highCommentDensity) parts.push("High comment density -- manual review recommended.");
+
+  return { summaryText: parts.join(" "), signals };
+}
+
+@Injectable()
+export class ReviewSummarizerService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async summarize(dto: SummarizeReviewDto, actorKey: string) {
+    const reviews = await this.prisma.reviewContext.findMany({
+      where: { pullRequestId: dto.pullRequestId },
+      orderBy: { reviewedAt: "asc" },
+    });
+
+    if (reviews.length === 0) {
+      throw new NotFoundException(
+        `No review context found for PR ${dto.pullRequestId}`,
+      );
+    }
+
+    const { summaryText, signals } = buildSummary(dto.pullRequestId, reviews);
+
+    const record = await this.prisma.reviewSummary.upsert({
+      where: { pullRequestId: dto.pullRequestId },
+      create: {
+        pullRequestId: dto.pullRequestId,
+        summaryText,
+        keySignals: signals as unknown as Prisma.InputJsonValue,
+        modelVersion: SUMMARIZER_MODEL_VERSION,
+      },
+      update: {
+        summaryText,
+        keySignals: signals as unknown as Prisma.InputJsonValue,
+        modelVersion: SUMMARIZER_MODEL_VERSION,
+        humanOverride: false,
+        overriddenBy: null,
+        overrideNote: null,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "review.summarized",
+      resourceType: "review_summary",
+      resourceId: record.id,
+      summary: `PR ${dto.pullRequestId} summarized: ${signals.reviewCount} reviews, contested=${signals.contested}`,
+      metadata: {
+        modelVersion: SUMMARIZER_MODEL_VERSION,
+        signals,
+      } as unknown as Prisma.InputJsonValue,
+    });
+
+    return record;
+  }
+
+  @MapDbErrors()
+  async getByPr(pullRequestId: string) {
+    const record = await this.prisma.reviewSummary.findUnique({
+      where: { pullRequestId },
+    });
+    if (!record) throw new NotFoundException("No summary found for this PR -- run summarize first");
+    return record;
+  }
+
+  @MapDbErrors()
+  async override(pullRequestId: string, actorKey: string, dto: OverrideSummaryDto) {
+    const existing = await this.prisma.reviewSummary.findUnique({
+      where: { pullRequestId },
+    });
+    if (!existing) throw new NotFoundException("No summary found -- run summarize first");
+
+    const updated = await this.prisma.reviewSummary.update({
+      where: { pullRequestId },
+      data: {
+        summaryText: dto.summaryText,
+        humanOverride: true,
+        overriddenBy: actorKey,
+        overrideNote: dto.overrideNote ?? null,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "review.summary.overridden",
+      resourceType: "review_summary",
+      resourceId: existing.id,
+      summary: `Human override on PR ${pullRequestId} summary`,
+      metadata: { overrideNote: dto.overrideNote } as Prisma.InputJsonValue,
+    });
+
+    return updated;
+  }
+
+  @MapDbErrors()
+  async list() {
+    return this.prisma.reviewSummary.findMany({
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/apps/api/src/modules/ticket-classifier/ticket-classifier.controller.ts
+++ b/apps/api/src/modules/ticket-classifier/ticket-classifier.controller.ts
@@ -1,0 +1,53 @@
+import {
+  Body,
+  Controller,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Patch,
+  Post,
+  Query,
+  Req,
+  UseGuards,
+} from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import {
+  ClassifyTicketDto,
+  OverrideClassificationDto,
+  TicketClassifierService,
+} from "./ticket-classifier.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("ticket-classifier")
+@UseGuards(OwnerKeyGuard)
+export class TicketClassifierController {
+  constructor(private readonly service: TicketClassifierService) {}
+
+  @Post("classify")
+  @HttpCode(HttpStatus.OK)
+  classify(@Body() dto: ClassifyTicketDto, @Req() req: Request) {
+    return this.service.classify(dto, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get("ticket/:ticketId")
+  getByTicket(@Param("ticketId") ticketId: string) {
+    return this.service.getByTicket(ticketId);
+  }
+
+  @Patch("ticket/:ticketId/override")
+  override(
+    @Param("ticketId") ticketId: string,
+    @Body() dto: OverrideClassificationDto,
+    @Req() req: Request,
+  ) {
+    return this.service.override(ticketId, (req as OwnerKeyRequest).ownerKey, dto);
+  }
+
+  @Get("route/:route")
+  listByRoute(@Param("route") route: string) {
+    return this.service.listByRoute(route);
+  }
+}

--- a/apps/api/src/modules/ticket-classifier/ticket-classifier.module.ts
+++ b/apps/api/src/modules/ticket-classifier/ticket-classifier.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { TicketClassifierController } from "./ticket-classifier.controller.js";
+import { TicketClassifierService } from "./ticket-classifier.service.js";
+
+@Module({
+  controllers: [TicketClassifierController],
+  providers: [TicketClassifierService, PrismaService, AuditService],
+  exports: [TicketClassifierService],
+})
+export class TicketClassifierModule {}

--- a/apps/api/src/modules/ticket-classifier/ticket-classifier.service.ts
+++ b/apps/api/src/modules/ticket-classifier/ticket-classifier.service.ts
@@ -1,0 +1,275 @@
+/**
+ * AI-211: First-pass support ticket classification and routing.
+ *
+ * Uses explicit, inspectable rules (keyword signals + category/priority weights)
+ * to assign a suggestedCategory, suggestedPriority, and suggestedRoute with a
+ * confidence score. Humans can override any result at any time.
+ */
+
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+} from "@nestjs/common";
+import { IsString, IsOptional } from "class-validator";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+
+export const CLASSIFIER_MODEL_VERSION = "rules-v1.0.0" as const;
+
+export const ROUTES = [
+  "tier1-auto",
+  "tier1-human",
+  "tier2-escalate",
+  "maintainer",
+  "security",
+] as const;
+export type Route = (typeof ROUTES)[number];
+
+export interface ClassificationSignals {
+  categoryWeight: number;
+  priorityWeight: number;
+  keywordHits: string[];
+  bodyLengthScore: number;
+  tagCount: number;
+}
+
+export interface ClassificationResult {
+  suggestedCategory: string;
+  suggestedPriority: string;
+  suggestedRoute: Route;
+  confidence: number;
+  signals: ClassificationSignals;
+  modelVersion: string;
+}
+
+export class ClassifyTicketDto {
+  @IsString()
+  ticketId!: string;
+}
+
+export class OverrideClassificationDto {
+  @IsString()
+  suggestedCategory!: string;
+
+  @IsString()
+  suggestedPriority!: string;
+
+  @IsString()
+  suggestedRoute!: string;
+
+  @IsOptional()
+  @IsString()
+  overrideNote?: string;
+}
+
+const KEYWORD_ROUTE_MAP: Record<string, Route> = {
+  exploit: "security",
+  abuse: "security",
+  spam: "security",
+  compromised: "security",
+  appeal: "maintainer",
+  dispute: "maintainer",
+  "false positive": "maintainer",
+  urgent: "tier2-escalate",
+  critical: "tier2-escalate",
+  blocked: "tier2-escalate",
+  payout: "tier1-human",
+  verification: "tier1-human",
+};
+
+const CATEGORY_WEIGHT: Record<string, number> = {
+  abuse: 0.9,
+  appeal: 0.8,
+  verification: 0.6,
+  payout: 0.6,
+  bug: 0.4,
+};
+
+const PRIORITY_WEIGHT: Record<string, number> = {
+  urgent: 0.9,
+  high: 0.7,
+  normal: 0.4,
+  low: 0.2,
+};
+
+function classifyText(
+  subject: string,
+  body: string,
+  category: string,
+  priority: string,
+  tags: string[],
+): ClassificationResult {
+  const text = `${subject} ${body}`.toLowerCase();
+
+  const keywordHits: string[] = [];
+  let routeFromKeyword: Route | null = null;
+
+  for (const [kw, route] of Object.entries(KEYWORD_ROUTE_MAP)) {
+    if (text.includes(kw)) {
+      keywordHits.push(kw);
+      if (!routeFromKeyword) routeFromKeyword = route;
+    }
+  }
+
+  const categoryWeight = CATEGORY_WEIGHT[category] ?? 0.3;
+  const priorityWeight = PRIORITY_WEIGHT[priority] ?? 0.3;
+  const bodyLengthScore = Math.min(body.length / 500, 1.0);
+  const tagCount = tags.length;
+
+  const signals: ClassificationSignals = {
+    categoryWeight,
+    priorityWeight,
+    keywordHits,
+    bodyLengthScore,
+    tagCount,
+  };
+
+  const confidence = Math.min(
+    (categoryWeight * 0.35 +
+      priorityWeight * 0.35 +
+      (keywordHits.length > 0 ? 0.2 : 0) +
+      bodyLengthScore * 0.1),
+    1.0,
+  );
+
+  let suggestedRoute: Route;
+  if (routeFromKeyword) {
+    suggestedRoute = routeFromKeyword;
+  } else if (confidence >= 0.75) {
+    suggestedRoute = "tier1-auto";
+  } else if (confidence >= 0.5) {
+    suggestedRoute = "tier1-human";
+  } else {
+    suggestedRoute = "tier2-escalate";
+  }
+
+  return {
+    suggestedCategory: category,
+    suggestedPriority: priority,
+    suggestedRoute,
+    confidence: Math.round(confidence * 1000) / 1000,
+    signals,
+    modelVersion: CLASSIFIER_MODEL_VERSION,
+  };
+}
+
+@Injectable()
+export class TicketClassifierService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async classify(dto: ClassifyTicketDto, actorKey: string) {
+    const ticket = await this.prisma.supportTicket.findUnique({
+      where: { id: dto.ticketId },
+    });
+    if (!ticket) throw new NotFoundException("Support ticket not found");
+
+    const tags: string[] = JSON.parse(ticket.tags ?? "[]");
+
+    const result = classifyText(
+      ticket.subject,
+      ticket.body,
+      ticket.category,
+      ticket.priority,
+      tags,
+    );
+
+    const classification = await this.prisma.ticketClassification.upsert({
+      where: { ticketId: dto.ticketId },
+      create: {
+        ticketId: dto.ticketId,
+        suggestedCategory: result.suggestedCategory,
+        suggestedPriority: result.suggestedPriority,
+        suggestedRoute: result.suggestedRoute,
+        confidence: result.confidence,
+        signals: result.signals as unknown as Prisma.InputJsonValue,
+        modelVersion: result.modelVersion,
+      },
+      update: {
+        suggestedCategory: result.suggestedCategory,
+        suggestedPriority: result.suggestedPriority,
+        suggestedRoute: result.suggestedRoute,
+        confidence: result.confidence,
+        signals: result.signals as unknown as Prisma.InputJsonValue,
+        modelVersion: result.modelVersion,
+        humanOverride: false,
+        overriddenBy: null,
+        overrideNote: null,
+        overriddenAt: null,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "ticket.classified",
+      resourceType: "ticket_classification",
+      resourceId: classification.id,
+      summary: `Ticket ${dto.ticketId} classified as route=${result.suggestedRoute} confidence=${result.confidence}`,
+      metadata: { modelVersion: result.modelVersion, signals: result.signals } as unknown as Prisma.InputJsonValue,
+    });
+
+    return classification;
+  }
+
+  @MapDbErrors()
+  async getByTicket(ticketId: string) {
+    const record = await this.prisma.ticketClassification.findUnique({
+      where: { ticketId },
+    });
+    if (!record) throw new NotFoundException("No classification found for this ticket");
+    return record;
+  }
+
+  @MapDbErrors()
+  async override(ticketId: string, actorKey: string, dto: OverrideClassificationDto) {
+    const existing = await this.prisma.ticketClassification.findUnique({
+      where: { ticketId },
+    });
+    if (!existing) throw new NotFoundException("No classification found -- run classify first");
+
+    if (!ROUTES.includes(dto.suggestedRoute as Route)) {
+      throw new BadRequestException(`Invalid route. Must be one of: ${ROUTES.join(", ")}`);
+    }
+
+    const updated = await this.prisma.ticketClassification.update({
+      where: { ticketId },
+      data: {
+        suggestedCategory: dto.suggestedCategory,
+        suggestedPriority: dto.suggestedPriority,
+        suggestedRoute: dto.suggestedRoute,
+        humanOverride: true,
+        overriddenBy: actorKey,
+        overrideNote: dto.overrideNote ?? null,
+        overriddenAt: new Date(),
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "ticket.classification.overridden",
+      resourceType: "ticket_classification",
+      resourceId: existing.id,
+      summary: `Human override on ticket ${ticketId}: route=${dto.suggestedRoute}`,
+      metadata: { overrideNote: dto.overrideNote } as Prisma.InputJsonValue,
+    });
+
+    return updated;
+  }
+
+  @MapDbErrors()
+  async listByRoute(route: string) {
+    if (!ROUTES.includes(route as Route)) {
+      throw new BadRequestException(`Invalid route. Must be one of: ${ROUTES.join(", ")}`);
+    }
+    return this.prisma.ticketClassification.findMany({
+      where: { suggestedRoute: route },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/docs/ai-automation-pipeline.md
+++ b/docs/ai-automation-pipeline.md
@@ -1,0 +1,131 @@
+# AI Automation Pipeline
+
+Covers issues AI-211 through AI-214. Four modules that add first-pass
+classification, review summarization, budget exception recommendations,
+and continuous model monitoring to the Soroban Dev Console API.
+
+---
+
+## Modules
+
+### ticket-classifier (AI-211)
+
+**Route:** `POST /ticket-classifier/classify`
+
+Runs a rule-based classifier over an existing support ticket and writes a
+`TicketClassification` record. Inputs are explicit: subject, body, category,
+priority, and tags. Outputs are explicit: suggestedCategory, suggestedPriority,
+suggestedRoute, confidence (0-1), and a signals breakdown.
+
+Routes:
+- `tier1-auto` -- high confidence, no human needed
+- `tier1-human` -- moderate confidence, human reviews before acting
+- `tier2-escalate` -- low confidence or complex signals
+- `maintainer` -- appeal or dispute keywords detected
+- `security` -- abuse, exploit, or compromise keywords detected
+
+Human override: `PATCH /ticket-classifier/ticket/:ticketId/override`
+Sets `humanOverride=true`, records who overrode and why. The original
+model output is preserved in the signals field for audit.
+
+Confidence formula (weights sum to 1.0):
+
+    confidence = categoryWeight(0.35) + priorityWeight(0.35) + keywordBonus(0.20) + bodyLengthScore(0.10)
+
+Model version: `rules-v1.0.0` -- bump the constant in the service when
+rules change so snapshots remain attributable.
+
+---
+
+### review-summarizer (AI-212)
+
+**Route:** `POST /review-summarizer/summarize`
+
+Reads all `ReviewContext` records for a pull request and compresses them
+into a `ReviewSummary` with a plain-text summaryText and a structured
+keySignals object. Designed as input for human appeal triage, not as a
+final decision.
+
+Signals captured: reviewCount, approvalCount, approvalRatio,
+totalComments, totalRequestedChanges, latestMergeStatus,
+uniqueReviewers, conflictingDecisions.
+
+Human override: `PATCH /review-summarizer/pr/:pullRequestId/override`
+Allows a maintainer to substitute the generated summaryText and mark
+the record as human-reviewed.
+
+---
+
+### budget-exception (AI-213)
+
+**Route:** `POST /budget-exception/recommend`
+
+Derives utilization, pacing, and concentration signals from
+`OrganizationBudget` and `PointReservation` records, then recommends
+one of: `review`, `no-review`, or `escalate`. Final decisions always
+stay with a human via `PATCH /budget-exception/org/:organizationId/decide`.
+
+Thresholds (tunable via constant):
+- utilization >= 0.95 -> escalate (confidence 0.90)
+- utilization >= 0.80 or highConcentration -> review (confidence 0.75)
+- otherwise -> no-review (confidence 0.80)
+
+Concentration flag: a single contributor holds >= 50% of all points
+in the organization.
+
+---
+
+### ai-monitor (AI-214)
+
+**Route:** `POST /ai-monitor/snapshot`
+
+Records a point-in-time `AiMetricSnapshot`. Each snapshot is immutable.
+Four metric types are tracked:
+
+| Metric | Alert when | Threshold |
+|---|---|---|
+| override_rate | value > threshold | 0.25 |
+| classification_precision | value < threshold | 0.70 |
+| fairness_drift | value > threshold | 0.15 |
+| queue_health | value < threshold | 0.50 |
+
+`GET /ai-monitor/alerts` -- returns all snapshots where alertTriggered=true.
+`GET /ai-monitor/summary` -- returns latest value per metric type.
+
+For automated collection use `scripts/check-model-drift.ts`.
+
+---
+
+## Shared Design Constraints (all four modules)
+
+1. **Explicit inputs and outputs.** Every module exposes its signals as
+   a JSON column. Nothing is hidden inside opaque model weights.
+
+2. **Measurable behavior.** Model version is stored on every record.
+   Changing rules requires bumping the version constant so before/after
+   comparisons are possible.
+
+3. **Human override always available.** Every classification, summary,
+   and recommendation has a dedicated override endpoint that records
+   who overrode, when, and why. The original output is never deleted.
+
+---
+
+## Adding or Tuning Rules
+
+- Ticket classifier: edit `KEYWORD_ROUTE_MAP`, `CATEGORY_WEIGHT`, and
+  `PRIORITY_WEIGHT` in `ticket-classifier.service.ts`, then bump
+  `CLASSIFIER_MODEL_VERSION`.
+- Budget exception: edit `UTILIZATION_REVIEW_THRESHOLD`,
+  `UTILIZATION_ESCALATE_THRESHOLD`, and `CONCENTRATION_RATIO` in
+  `budget-exception.service.ts`, then bump `EXCEPTION_MODEL_VERSION`.
+- Monitor alerts: edit `ALERT_THRESHOLDS` in `ai-monitor.service.ts`,
+  then bump `MONITOR_MODEL_VERSION`.
+
+---
+
+## Related Docs
+
+- `docs/review-routing.md` -- upstream routing conventions
+- `docs/governance.md` -- override approval process
+- `docs/observability.md` -- metric collection setup

--- a/scripts/check-model-drift.ts
+++ b/scripts/check-model-drift.ts
@@ -1,0 +1,129 @@
+/**
+ * AI-214: Automated metric collection for the AI monitoring pipeline.
+ *
+ * Reads live data from the database and posts snapshots to the
+ * ai-monitor endpoint. Run on a schedule (cron, CI, or manually)
+ * to keep the drift dashboard current.
+ *
+ * Usage:
+ *   tsx scripts/check-model-drift.ts
+ *
+ * Env vars required:
+ *   DATABASE_URL  -- SQLite path (same as API)
+ *   API_BASE_URL  -- e.g. http://localhost:4000
+ *   MONITOR_OWNER_KEY -- x-owner-key for the API request
+ */
+
+import { PrismaClient } from "@prisma/client";
+
+const API_BASE = process.env.API_BASE_URL ?? "http://localhost:4000";
+const OWNER_KEY = process.env.MONITOR_OWNER_KEY ?? "";
+const WINDOW_HOURS = 24;
+
+const prisma = new PrismaClient();
+
+async function postSnapshot(
+  metricType: string,
+  value: number,
+  metadata: Record<string, unknown>,
+) {
+  const res = await fetch(`${API_BASE}/ai-monitor/snapshot`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-owner-key": OWNER_KEY,
+    },
+    body: JSON.stringify({ metricType, value, windowHours: WINDOW_HOURS, metadata }),
+  });
+  if (!res.ok) throw new Error(`snapshot failed: ${res.status} ${await res.text()}`);
+  return res.json();
+}
+
+async function measureOverrideRate() {
+  const since = new Date(Date.now() - WINDOW_HOURS * 60 * 60 * 1000);
+  const [total, overridden] = await Promise.all([
+    prisma.ticketClassification.count({ where: { createdAt: { gte: since } } }),
+    prisma.ticketClassification.count({ where: { humanOverride: true, createdAt: { gte: since } } }),
+  ]);
+  const rate = total > 0 ? overridden / total : 0;
+  return { value: Math.round(rate * 1000) / 1000, metadata: { total, overridden, windowHours: WINDOW_HOURS } };
+}
+
+async function measureClassificationPrecision() {
+  const since = new Date(Date.now() - WINDOW_HOURS * 60 * 60 * 1000);
+  const [total, highConfidence] = await Promise.all([
+    prisma.ticketClassification.count({ where: { createdAt: { gte: since } } }),
+    prisma.ticketClassification.count({ where: { confidence: { gte: 0.7 }, createdAt: { gte: since } } }),
+  ]);
+  const precision = total > 0 ? highConfidence / total : 1;
+  return { value: Math.round(precision * 1000) / 1000, metadata: { total, highConfidence, windowHours: WINDOW_HOURS } };
+}
+
+async function measureFairnessDrift() {
+  const orgs = await prisma.organizationBudget.findMany({
+    select: { organizationId: true, usedPoints: true, capPoints: true },
+  });
+  if (orgs.length < 2) return { value: 0, metadata: { orgCount: orgs.length } };
+  const ratios = orgs
+    .filter((o) => o.capPoints > 0)
+    .map((o) => o.usedPoints / o.capPoints);
+  if (ratios.length < 2) return { value: 0, metadata: { orgCount: orgs.length } };
+  const mean = ratios.reduce((a, b) => a + b, 0) / ratios.length;
+  const variance = ratios.reduce((sum, r) => sum + Math.pow(r - mean, 2), 0) / ratios.length;
+  const drift = Math.round(Math.sqrt(variance) * 1000) / 1000;
+  return { value: drift, metadata: { orgCount: orgs.length, mean: Math.round(mean * 1000) / 1000 } };
+}
+
+async function measureQueueHealth() {
+  const [total, open] = await Promise.all([
+    prisma.supportTicket.count(),
+    prisma.supportTicket.count({ where: { status: "open" } }),
+  ]);
+  const resolved = total - open;
+  const health = total > 0 ? resolved / total : 1;
+  return { value: Math.round(health * 1000) / 1000, metadata: { total, open, resolved } };
+}
+
+async function main() {
+  if (!OWNER_KEY) {
+    console.error("MONITOR_OWNER_KEY is required");
+    process.exit(1);
+  }
+
+  console.log(`[check-model-drift] window=${WINDOW_HOURS}h api=${API_BASE}`);
+
+  const metrics: Array<{ type: string; fn: () => Promise<{ value: number; metadata: Record<string, unknown> }> }> = [
+    { type: "override_rate", fn: measureOverrideRate },
+    { type: "classification_precision", fn: measureClassificationPrecision },
+    { type: "fairness_drift", fn: measureFairnessDrift },
+    { type: "queue_health", fn: measureQueueHealth },
+  ];
+
+  let hasAlert = false;
+
+  for (const { type, fn } of metrics) {
+    try {
+      const { value, metadata } = await fn();
+      const snapshot = await postSnapshot(type, value, metadata);
+      const alert = snapshot.alertTriggered ? " [ALERT]" : "";
+      console.log(`  ${type}: ${value}${alert}`);
+      if (snapshot.alertTriggered) hasAlert = true;
+    } catch (err) {
+      console.error(`  ${type}: failed --`, err);
+    }
+  }
+
+  await prisma.$disconnect();
+
+  if (hasAlert) {
+    console.log("[check-model-drift] one or more alert thresholds breached -- review /ai-monitor/alerts");
+    process.exit(2);
+  }
+
+  console.log("[check-model-drift] all metrics within thresholds");
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
AI-211: ticket-classifier -- rule-based classification and routing
  - suggestedCategory, suggestedPriority, suggestedRoute, confidence
  - keyword signal map with 5 route tiers
  - human override endpoint with full audit trail

AI-212: review-summarizer -- compress review threads for appeal triage
  - aggregates ReviewContext records into ReviewSummary
  - keySignals: approvalRatio, contested, uniqueReviewers
  - human override endpoint preserves original output

AI-213: budget-exception -- signal-based org exception recommendations
  - derives utilization, pacing, concentration signals
  - recommends review / no-review / escalate
  - human decision endpoint, final call always with humans

AI-214: ai-monitor -- continuous model drift and quality monitoring
  - immutable AiMetricSnapshot per metric type
  - alert thresholds for override_rate, precision, fairness, queue health
  - scripts/check-model-drift.ts for scheduled collection

Also: register BudgetModule (was imported but missing from imports array) Prisma: add TicketClassification, ReviewSummary,
        BudgetExceptionRecommendation, AiMetricSnapshot models
Docs: docs/ai-automation-pipeline.md

closes #428
closes #429 
closes #430 
closes #431 