### PR TITLE
feat: build reusable feedback-tagging assistant (closes #597)

### DIFF
--- a/apps/api/prisma/migrations/20260625120000_add_feedback_tag_batch/migration.sql
+++ b/apps/api/prisma/migrations/20260625120000_add_feedback_tag_batch/migration.sql
@@ -1,0 +1,15 @@
+-- CreateTable
+CREATE TABLE "feedback_tag_batches" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "batch_id" TEXT NOT NULL,
+    "item_count" INTEGER NOT NULL,
+    "tagged_items" JSONB NOT NULL,
+    "tag_summary" JSONB NOT NULL,
+    "needs_review_count" INTEGER NOT NULL DEFAULT 0,
+    "model_version" TEXT NOT NULL,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" DATETIME NOT NULL
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "feedback_tag_batches_batch_id_key" ON "feedback_tag_batches"("batch_id");

--- a/apps/api/prisma/schema.prisma
+++ b/apps/api/prisma/schema.prisma
@@ -446,3 +446,18 @@ model AiMetricSnapshot {
   @@map("ai_metric_snapshots")
 }
 
+/// AI-935: Reusable feedback tagging batch record.
+model FeedbackTagBatch {
+  id               String   @id @default(cuid())
+  batchId          String   @unique @map("batch_id")
+  itemCount        Int      @map("item_count")
+  taggedItems      Json     @map("tagged_items")
+  tagSummary       Json     @map("tag_summary")
+  needsReviewCount Int      @default(0) @map("needs_review_count")
+  modelVersion     String   @map("model_version")
+  createdAt        DateTime @default(now()) @map("created_at")
+  updatedAt        DateTime @updatedAt @map("updated_at")
+
+  @@map("feedback_tag_batches")
+}
+

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -21,6 +21,7 @@ import { TicketClassifierModule } from "./modules/ticket-classifier/ticket-class
 import { ReviewSummarizerModule } from "./modules/review-summarizer/review-summarizer.module.js";
 import { BudgetExceptionModule } from "./modules/budget-exception/budget-exception.module.js";
 import { AiMonitorModule } from "./modules/ai-monitor/ai-monitor.module.js";
+import { FeedbackTaggerModule } from "./modules/feedback-tagger/feedback-tagger.module.js";
 
 @Module({
   imports: [
@@ -47,6 +48,7 @@ import { AiMonitorModule } from "./modules/ai-monitor/ai-monitor.module.js";
     BudgetModule,
     TicketClassifierModule,
     ReviewSummarizerModule,
+    FeedbackTaggerModule,
     BudgetExceptionModule,
     AiMonitorModule,
   ]

--- a/apps/api/src/modules/feedback-tagger/feedback-tagger.controller.ts
+++ b/apps/api/src/modules/feedback-tagger/feedback-tagger.controller.ts
@@ -1,0 +1,28 @@
+import { Body, Controller, Get, HttpCode, HttpStatus, Param, Post, Req, UseGuards } from "@nestjs/common";
+import type { Request } from "express";
+import { OwnerKeyGuard } from "../../auth/owner-key.guard.js";
+import { TagFeedbackDto, FeedbackTaggerService } from "./feedback-tagger.service.js";
+
+type OwnerKeyRequest = Request & { ownerKey: string };
+
+@Controller("feedback-tagger")
+@UseGuards(OwnerKeyGuard)
+export class FeedbackTaggerController {
+  constructor(private readonly service: FeedbackTaggerService) {}
+
+  @Post("tag")
+  @HttpCode(HttpStatus.OK)
+  tag(@Body() dto: TagFeedbackDto, @Req() req: Request) {
+    return this.service.tag(dto, (req as OwnerKeyRequest).ownerKey);
+  }
+
+  @Get("batch/:batchId")
+  getByBatch(@Param("batchId") batchId: string) {
+    return this.service.getByBatch(batchId);
+  }
+
+  @Get("list")
+  list() {
+    return this.service.list();
+  }
+}

--- a/apps/api/src/modules/feedback-tagger/feedback-tagger.module.ts
+++ b/apps/api/src/modules/feedback-tagger/feedback-tagger.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { FeedbackTaggerController } from "./feedback-tagger.controller.js";
+import { FeedbackTaggerService } from "./feedback-tagger.service.js";
+
+@Module({
+  controllers: [FeedbackTaggerController],
+  providers: [FeedbackTaggerService, PrismaService, AuditService],
+  exports: [FeedbackTaggerService],
+})
+export class FeedbackTaggerModule {}

--- a/apps/api/src/modules/feedback-tagger/feedback-tagger.service.spec.ts
+++ b/apps/api/src/modules/feedback-tagger/feedback-tagger.service.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { FeedbackTaggerService, TagFeedbackDto, FEEDBACK_TAGGER_MODEL_VERSION } from "./feedback-tagger.service.js";
+
+class MockPrisma {
+  feedbackTagBatch = {
+    upsert: async (args: unknown) => ({ id: "batch-1", ...args }),
+    findUnique: async () => null,
+    findMany: async () => [],
+  };
+}
+
+class MockAudit {
+  public logs: unknown[] = [];
+  async log(entry: unknown) {
+    this.logs.push(entry);
+  }
+}
+
+describe("FeedbackTaggerService", () => {
+  let service: FeedbackTaggerService;
+  let prisma: MockPrisma;
+  let audit: MockAudit;
+
+  beforeEach(() => {
+    prisma = new MockPrisma();
+    audit = new MockAudit();
+    service = new FeedbackTaggerService(prisma as never, audit as never);
+  });
+
+  it("tags feedback items and returns an upsert record", async () => {
+    const dto: TagFeedbackDto = {
+      batchId: "batch-1",
+      feedbackItems: ["The UI is confusing", "Please add dark mode"],
+      context: "release feedback",
+    };
+
+    const result = await service.tag(dto, "owner-key-123");
+
+    assert.equal(result.id, "batch-1");
+    assert.equal(result.batchId, dto.batchId);
+  });
+
+  it("lists batches", async () => {
+    const items = await service.list();
+    assert.deepEqual(items, []);
+  });
+});

--- a/apps/api/src/modules/feedback-tagger/feedback-tagger.service.ts
+++ b/apps/api/src/modules/feedback-tagger/feedback-tagger.service.ts
@@ -1,0 +1,142 @@
+/**
+ * AI-935: Build a reusable feedback-tagging assistant.
+ */
+
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { IsString, IsArray, IsOptional } from "class-validator";
+import { Prisma } from "@prisma/client";
+import { PrismaService } from "../../lib/prisma.service.js";
+import { AuditService } from "../../lib/audit.service.js";
+import { MapDbErrors } from "../../lib/db-error.mapper.js";
+
+export const FEEDBACK_TAGGER_MODEL_VERSION = "rules-v1.0.0" as const;
+
+export type FeedbackTag =
+  | "bug-report"
+  | "feature-request"
+  | "performance"
+  | "ux"
+  | "documentation"
+  | "question"
+  | "positive"
+  | "unclear";
+
+export interface TaggedFeedback {
+  text: string;
+  tags: FeedbackTag[];
+  confidence: number;
+  needsManualReview: boolean;
+}
+
+export class TagFeedbackDto {
+  @IsString()
+  batchId!: string;
+
+  @IsArray()
+  feedbackItems!: string[];
+
+  @IsOptional()
+  @IsString()
+  context?: string;
+}
+
+const TAG_RULES: Array<{ pattern: RegExp; tag: FeedbackTag; weight: number }> = [
+  { pattern: /bug|error|broken|crash|fail|not working|doesn't work/i, tag: "bug-report", weight: 1 },
+  { pattern: /slow|performance|latency|timeout|lag/i, tag: "performance", weight: 1 },
+  { pattern: /feature|request|would be nice|add|support for|please add/i, tag: "feature-request", weight: 1 },
+  { pattern: /ui|ux|design|layout|button|click|interface|confusing/i, tag: "ux", weight: 1 },
+  { pattern: /doc|documentation|readme|example|unclear|how to/i, tag: "documentation", weight: 1 },
+  { pattern: /question|how|what|why|where|when\?/i, tag: "question", weight: 1 },
+  { pattern: /great|love|awesome|excellent|good job|well done|thanks/i, tag: "positive", weight: 1 },
+];
+
+function tagItem(text: string): TaggedFeedback {
+  const matchedTags: FeedbackTag[] = [];
+  let totalWeight = 0;
+
+  for (const rule of TAG_RULES) {
+    if (rule.pattern.test(text)) {
+      matchedTags.push(rule.tag);
+      totalWeight += rule.weight;
+    }
+  }
+
+  const tags = matchedTags.length > 0 ? matchedTags : (["unclear"] as FeedbackTag[]);
+  const confidence = matchedTags.length > 0
+    ? Math.min(totalWeight / TAG_RULES.length + 0.3, 1)
+    : 0.1;
+
+  return {
+    text,
+    tags,
+    confidence: Math.round(confidence * 1000) / 1000,
+    needsManualReview: confidence < 0.5 || tags.includes("unclear"),
+  };
+}
+
+function buildSummary(tagged: TaggedFeedback[]): Record<FeedbackTag, number> {
+  const summary = {} as Record<FeedbackTag, number>;
+  for (const item of tagged) {
+    for (const tag of item.tags) {
+      summary[tag] = (summary[tag] ?? 0) + 1;
+    }
+  }
+  return summary;
+}
+
+@Injectable()
+export class FeedbackTaggerService {
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly audit: AuditService,
+  ) {}
+
+  @MapDbErrors()
+  async tag(dto: TagFeedbackDto, actorKey: string) {
+    const taggedItems = dto.feedbackItems.map(tagItem);
+    const tagSummary = buildSummary(taggedItems);
+    const needsReviewCount = taggedItems.filter((t) => t.needsManualReview).length;
+
+    const record = await this.prisma.feedbackTagBatch.upsert({
+      where: { batchId: dto.batchId },
+      create: {
+        batchId: dto.batchId,
+        itemCount: dto.feedbackItems.length,
+        taggedItems: taggedItems as unknown as Prisma.InputJsonValue,
+        tagSummary: tagSummary as unknown as Prisma.InputJsonValue,
+        needsReviewCount,
+        modelVersion: FEEDBACK_TAGGER_MODEL_VERSION,
+      },
+      update: {
+        itemCount: dto.feedbackItems.length,
+        taggedItems: taggedItems as unknown as Prisma.InputJsonValue,
+        tagSummary: tagSummary as unknown as Prisma.InputJsonValue,
+        needsReviewCount,
+        modelVersion: FEEDBACK_TAGGER_MODEL_VERSION,
+      },
+    });
+
+    void this.audit.log({
+      actor: actorKey,
+      action: "feedback.batch.tagged",
+      resourceType: "feedback_tag_batch",
+      resourceId: record.id,
+      summary: `Batch ${dto.batchId}: ${dto.feedbackItems.length} item(s) tagged, ${needsReviewCount} need review`,
+      metadata: { modelVersion: FEEDBACK_TAGGER_MODEL_VERSION, tagSummary } as Prisma.InputJsonValue,
+    });
+
+    return record;
+  }
+
+  @MapDbErrors()
+  async getByBatch(batchId: string) {
+    const record = await this.prisma.feedbackTagBatch.findUnique({ where: { batchId } });
+    if (!record) throw new NotFoundException("No feedback tag batch found for this ID");
+    return record;
+  }
+
+  @MapDbErrors()
+  async list() {
+    return this.prisma.feedbackTagBatch.findMany({ orderBy: { createdAt: "desc" } });
+  }
+}


### PR DESCRIPTION
closes #597 
Implements AI-935 by adding a feedback tagging assistant with tagging rules, batch persistence, audit logging, and a new FeedbackTagBatch Prisma model. Includes module registration, controller endpoints, and a basic service test.