### PR TITLE
feat: FE-233/FE-234 — toast patterns & read-only share UX

### DIFF
--- a/apps/web/app/share/[token]/page.tsx
+++ b/apps/web/app/share/[token]/page.tsx
@@ -16,6 +16,7 @@ import { importWorkspace, type SerializedWorkspace } from "@/lib/workspace-seria
 import { useAbiStore } from "@/store/useAbiStore";
 import { useWasmStore } from "@/store/useWasmStore";
 import { DependencyDiagnostics } from "@/components/dependency-diagnostics";
+import { ReadOnlyBanner } from "@/components/read-only-banner";
 import {
   Card,
   CardContent,
@@ -29,7 +30,6 @@ import {
   AlertTriangle,
   Ban,
   Clock,
-  Eye,
   FileCode,
   GitFork,
   Loader2,
@@ -133,17 +133,7 @@ export default function SharedWorkspacePage() {
   return (
     <div className="container mx-auto max-w-3xl space-y-6 p-6">
       {/* Read-only banner */}
-      <div className="flex items-center justify-between gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300">
-        <span className="flex items-center gap-2">
-          <Eye className="h-4 w-4 shrink-0" />
-          <span>
-            <strong>Read-only</strong> shared workspace — editing is disabled.
-          </span>
-        </span>
-        {isExpired && (
-          <Badge variant="destructive" className="shrink-0">Expired</Badge>
-        )}
-      </div>
+      <ReadOnlyBanner isExpired={!!isExpired} />
 
       {/* Dependency Diagnostics */}
       <DependencyDiagnostics

--- a/apps/web/components/__tests__/fe-233-fe-234.test.tsx
+++ b/apps/web/components/__tests__/fe-233-fe-234.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * FE-233 / FE-234: Regression tests for ReadOnlyBanner and useAppToast.
+ */
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { renderHook } from "@testing-library/react";
+import { ReadOnlyBanner } from "../read-only-banner";
+
+// ---------------------------------------------------------------------------
+// ReadOnlyBanner
+// ---------------------------------------------------------------------------
+
+vi.mock("@devconsole/ui", () => ({
+  Badge: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <span data-testid="badge" className={className}>{children}</span>
+  ),
+}));
+
+vi.mock("lucide-react", () => ({
+  Eye: ({ className, ...rest }: React.SVGProps<SVGSVGElement>) => (
+    <svg data-testid="eye-icon" className={className} {...rest} />
+  ),
+}));
+
+describe("ReadOnlyBanner", () => {
+  it("renders with role=status and read-only text", () => {
+    render(<ReadOnlyBanner />);
+    const banner = screen.getByRole("status");
+    expect(banner).toBeTruthy();
+    expect(banner.getAttribute("data-testid")).toBe("read-only-banner");
+    expect(banner.textContent).toContain("Read-only");
+  });
+
+  it("does not show Expired badge when isExpired is false", () => {
+    render(<ReadOnlyBanner isExpired={false} />);
+    expect(screen.queryByTestId("badge")).toBeNull();
+  });
+
+  it("shows Expired badge when isExpired is true", () => {
+    render(<ReadOnlyBanner isExpired />);
+    const badge = screen.getByTestId("badge");
+    expect(badge.textContent).toContain("Expired");
+  });
+
+  it("has aria-label describing the widget", () => {
+    render(<ReadOnlyBanner />);
+    const banner = screen.getByRole("status");
+    expect(banner.getAttribute("aria-label")).toBe("Read-only workspace");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// useAppToast
+// ---------------------------------------------------------------------------
+
+import { useAppToast } from "@/hooks/use-app-toast";
+import * as sonner from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    loading: vi.fn(),
+    dismiss: vi.fn(),
+  },
+}));
+
+describe("useAppToast", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("success calls toast.success with 4s duration", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.success("Done!");
+    expect(sonner.toast.success).toHaveBeenCalledWith("Done!", { duration: 4000 });
+  });
+
+  it("error calls toast.error with 6s duration", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.error("Failed!");
+    expect(sonner.toast.error).toHaveBeenCalledWith("Failed!", { duration: 6000 });
+  });
+
+  it("warning calls toast.warning with 5s duration", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.warning("Careful!");
+    expect(sonner.toast.warning).toHaveBeenCalledWith("Careful!", { duration: 5000 });
+  });
+
+  it("info calls toast.info with 4s duration", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.info("FYI");
+    expect(sonner.toast.info).toHaveBeenCalledWith("FYI", { duration: 4000 });
+  });
+
+  it("loading calls toast.loading", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.loading("Loading…");
+    expect(sonner.toast.loading).toHaveBeenCalledWith("Loading…", {});
+  });
+
+  it("success passes through description and id options", () => {
+    const { result } = renderHook(() => useAppToast());
+    result.current.success("Saved", { description: "All good", id: "t1" });
+    expect(sonner.toast.success).toHaveBeenCalledWith("Saved", {
+      duration: 4000,
+      description: "All good",
+      id: "t1",
+    });
+  });
+});

--- a/apps/web/components/read-only-banner.tsx
+++ b/apps/web/components/read-only-banner.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+/**
+ * FE-234: Standalone read-only banner for the shared workspace view.
+ * Replaces the inline div so the read-only affordance is reusable and testable.
+ */
+
+import { Eye } from "lucide-react";
+import { Badge } from "@devconsole/ui";
+
+interface ReadOnlyBannerProps {
+  isExpired?: boolean;
+}
+
+export function ReadOnlyBanner({ isExpired = false }: ReadOnlyBannerProps) {
+  return (
+    <div
+      role="status"
+      aria-label="Read-only workspace"
+      data-testid="read-only-banner"
+      className="flex items-center justify-between gap-2 rounded-md border border-blue-200 bg-blue-50 px-4 py-2 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-300"
+    >
+      <span className="flex items-center gap-2">
+        <Eye className="h-4 w-4 shrink-0" aria-hidden />
+        <span>
+          <strong>Read-only</strong> shared workspace — editing is disabled.
+          Fork this workspace to make changes.
+        </span>
+      </span>
+      {isExpired && (
+        <Badge variant="destructive" className="shrink-0">
+          Expired
+        </Badge>
+      )}
+    </div>
+  );
+}

--- a/apps/web/hooks/use-app-toast.ts
+++ b/apps/web/hooks/use-app-toast.ts
@@ -1,0 +1,36 @@
+/**
+ * FE-233: Centralized toast hook for consistent success/warning/error patterns.
+ *
+ * Wraps sonner's `toast` with opinionated defaults so callers never have to
+ * pass duration, icon, or description boilerplate directly.
+ */
+import { toast } from "sonner";
+
+export type ToastOptions = {
+  description?: string;
+  /** Existing toast ID to replace (for loading → result transitions). */
+  id?: string | number;
+};
+
+export function useAppToast() {
+  return {
+    success(title: string, opts?: ToastOptions) {
+      toast.success(title, { duration: 4000, ...opts });
+    },
+    error(title: string, opts?: ToastOptions) {
+      toast.error(title, { duration: 6000, ...opts });
+    },
+    warning(title: string, opts?: ToastOptions) {
+      toast.warning(title, { duration: 5000, ...opts });
+    },
+    info(title: string, opts?: ToastOptions) {
+      toast.info(title, { duration: 4000, ...opts });
+    },
+    loading(title: string, opts?: Omit<ToastOptions, "id">) {
+      return toast.loading(title, { ...opts });
+    },
+    dismiss(id?: string | number) {
+      toast.dismiss(id);
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Resolves both **FE-233** and **FE-234** in a single PR.

### FE-233 — Upgrade toast and banner feedback patterns

- Added `hooks/use-app-toast.ts` — a thin wrapper around sonner that enforces consistent durations and makes call-sites uniform:
  | type | duration |
  |------|----------|
  | success | 4 s |
  | error | 6 s |
  | warning | 5 s |
  | info | 4 s |
  | loading | persistent (caller dismisses) |
- Supports `description` and `id` passthrough for loading → result toasts.

### FE-234 — Cleaner read-only share mode

- Extracted `components/read-only-banner.tsx` — replaces the inline `<div>` in the share page with a reusable, accessible component (`role=status`, `aria-label`, `data-testid`, optional Expired badge).
- Share page (`app/share/[token]/page.tsx`) now imports `ReadOnlyBanner`; redundant icon import removed.
- `ActionGuard` (via `useActionGuard`) already blocks all mutating actions on `/share/*` paths — no further wiring needed.

## Tests

10/10 vitest unit tests added in `components/__tests__/fe-233-fe-234.test.tsx`:
- ReadOnlyBanner: role, text, badge visibility, aria-label
- useAppToast: each variant's duration, options passthrough

`npm run typecheck -w web` — clean.

Closes #486
Closes #487